### PR TITLE
Fix azure pipeline and sonic-swss-common dependency conflict

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -33,6 +33,7 @@ jobs:
       sudo apt-get install -y \
           libboost-system-dev \
           libboost-thread-dev \
+          libboost-serialization-dev \
           googletest \
           libgtest-dev \
           libgmock-dev \
@@ -55,8 +56,8 @@ jobs:
         artifact: sonic-swss-common
       ${{ else }}:
         artifact: sonic-swss-common.${{ parameters.arch }}
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runVersion: 'specific'
+      runBranch: 128696
       path: '$(Build.SourcesDirectory)/sonic-swss-common'
     displayName: "Download sonic swss common deb packages"
   - script: |

--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -57,7 +57,8 @@ jobs:
       ${{ else }}:
         artifact: sonic-swss-common.${{ parameters.arch }}
       runVersion: 'specific'
-      runBranch: 128696
+      runId: 128696
+      runBranch: 'refs/heads/master'
       path: '$(Build.SourcesDirectory)/sonic-swss-common'
     displayName: "Download sonic swss common deb packages"
   - script: |


### PR DESCRIPTION
**How did you do it?**

Add libboost-serialization to the package list.
Use a specific swss-common build as the last version has some dependency conflicts.

*Specifying buildId as a temporary fix