### PR TITLE
Fix packet range check for relay-reply packets

### DIFF
--- a/src/relay.cpp
+++ b/src/relay.cpp
@@ -755,7 +755,7 @@ void callback_dual_tor(evutil_socket_t fd, short event, void *arg) {
         current_position = tmp;
 
         if (current_position + sizeof(struct dhcpv6_msg) > ((uint8_t *)ptr + buffer_sz)) {
-            syslog(LOG_WARNING, "Invalid DHCPv6 packet length %ld, no space for dhcpv6 msg header\n", buffer_sz);
+            syslog(LOG_WARNING, "Invalid DHCPv6 packet length %zu, no space for dhcpv6 msg header\n", buffer_sz);
             return;
         }
         auto msg = parse_dhcpv6_hdr(current_position);
@@ -837,7 +837,7 @@ void server_callback(evutil_socket_t fd, short event, void *arg) {
     }
 
     if (data < (int32_t)sizeof(struct dhcpv6_msg)) {
-        syslog(LOG_WARNING, "Invalid DHCPv6 packet length %d, no space for dhcpv6 msg header\n", len);
+        syslog(LOG_WARNING, "Invalid DHCPv6 packet length %zu, no space for dhcpv6 msg header\n", data);
 	return;
     }
 

--- a/src/relay.cpp
+++ b/src/relay.cpp
@@ -837,7 +837,7 @@ void server_callback(evutil_socket_t fd, short event, void *arg) {
     }
 
     if (data < (int32_t)sizeof(struct dhcpv6_msg)) {
-        syslog(LOG_WARNING, "Invalid DHCPv6 packet length %zu, no space for dhcpv6 msg header\n", data);
+        syslog(LOG_WARNING, "Invalid DHCPv6 packet length %d, no space for dhcpv6 msg header\n", data);
 	return;
     }
 

--- a/src/relay.cpp
+++ b/src/relay.cpp
@@ -834,54 +834,14 @@ void server_callback(evutil_socket_t fd, short event, void *arg) {
     }
 
     if (data < (int32_t)sizeof(struct dhcpv6_msg)) {
-        syslog(LOG_WARNING, "Invalid DHCPv6 header");
-        return;
+        syslog(LOG_WARNING, "Invalid DHCPv6 packet length %d, no space for dhcpv6 msg header\n", len);
+	return;
     }
 
     auto msg = parse_dhcpv6_hdr(message_buffer);
-    if (ntohs(msg->msg_type) == 0 || ntohs(msg->msg_type) > 14) {
-        return;
-    }
-    else {
-        counters[msg->msg_type]++;
-    }
-    std::string counterVlan = counter_table;
-    update_counter(config->state_db, counterVlan.append(config->interface), msg->msg_type);
-    if (msg->msg_type == DHCPv6_MESSAGE_TYPE_RELAY_REPL) {
-        relay_relay_reply(config->server_sock, message_buffer, data, config);
-    }
-}
-
-/**
- * @code                void server_callback_dual_tor(evutil_socket_t fd, short event, void *arg);
- * 
- * @brief               callback for libevent that is called everytime data is received at the server socket
- *
- * @param fd            filter socket
- * @param event         libevent triggered event  
- * @param arg           callback argument provided by user
- *
- * @return              none
- */
-void server_callback_dual_tor(evutil_socket_t fd, short event, void *arg) {
-    struct relay_config *config = (struct relay_config *)arg;
-    sockaddr_in6 from;
-    socklen_t len = sizeof(from);
-    int32_t data = 0;
-    static uint8_t message_buffer[BUFFER_SIZE];
-
-    if ((data = recvfrom(config->local_sock, message_buffer, BUFFER_SIZE, 0, (sockaddr *)&from, &len)) == -1) {
-        syslog(LOG_WARNING, "recv: Failed to receive data from server\n");
-        return;
-    }
-
-    if (data < (int32_t)sizeof(struct dhcpv6_msg)) {
-        syslog(LOG_WARNING, "Invalid DHCPv6 header");
-        return;
-    }
-
-    auto msg = parse_dhcpv6_hdr(message_buffer);
-    if (ntohs(msg->msg_type) == 0 || ntohs(msg->msg_type) > 14) {
+    // RFC3315 only
+    if (msg->msg_type < DHCPv6_MESSAGE_TYPE_SOLICIT || msg->msg_type > DHCPv6_MESSAGE_TYPE_RELAY_REPL) {
+        syslog(LOG_WARNING, "Unknown DHCPv6 message type %d\n", msg->msg_type);
         return;
     }
     else {
@@ -1029,12 +989,11 @@ void loop_relay(std::vector<relay_config> *vlans) {
     
         if (dual_tor_sock) {
             listen_event = event_new(base, filter, EV_READ|EV_PERSIST, callback_dual_tor, config);
-            server_listen_event = event_new(base, local_sock, EV_READ|EV_PERSIST, server_callback_dual_tor, config);
         }
         else {
             listen_event = event_new(base, filter, EV_READ|EV_PERSIST, callback, config);
-            server_listen_event = event_new(base, local_sock, EV_READ|EV_PERSIST, server_callback, config);
         }
+	server_listen_event = event_new(base, local_sock, EV_READ|EV_PERSIST, server_callback, config);
 
         if (listen_event == NULL || server_listen_event == NULL) {
             syslog(LOG_ERR, "libevent: Failed to create libevent\n");

--- a/src/relay.cpp
+++ b/src/relay.cpp
@@ -643,6 +643,7 @@ void callback(evutil_socket_t fd, short event, void *arg) {
     auto msg = parse_dhcpv6_hdr(current_position);
     // RFC3315 only
     if (msg->msg_type < DHCPv6_MESSAGE_TYPE_SOLICIT || msg->msg_type > DHCPv6_MESSAGE_TYPE_RELAY_REPL) {
+        update_counter(config->state_db, counterVlan.append(config->interface), DHCPv6_MESSAGE_TYPE_UNKNOWN);
         syslog(LOG_WARNING, "Unknown DHCPv6 message type %d\n", msg->msg_type);
         return;
     }
@@ -760,6 +761,7 @@ void callback_dual_tor(evutil_socket_t fd, short event, void *arg) {
         auto msg = parse_dhcpv6_hdr(current_position);
         // RFC3315 only
         if (msg->msg_type < DHCPv6_MESSAGE_TYPE_SOLICIT || msg->msg_type > DHCPv6_MESSAGE_TYPE_RELAY_REPL) {
+            update_counter(config->state_db, counterVlan.append(config->interface), DHCPv6_MESSAGE_TYPE_UNKNOWN);
             syslog(LOG_WARNING, "Unknown DHCPv6 message type %d\n", msg->msg_type);
             return;
         }
@@ -841,6 +843,7 @@ void server_callback(evutil_socket_t fd, short event, void *arg) {
     auto msg = parse_dhcpv6_hdr(message_buffer);
     // RFC3315 only
     if (msg->msg_type < DHCPv6_MESSAGE_TYPE_SOLICIT || msg->msg_type > DHCPv6_MESSAGE_TYPE_RELAY_REPL) {
+        update_counter(config->state_db, counterVlan.append(config->interface), DHCPv6_MESSAGE_TYPE_UNKNOWN);
         syslog(LOG_WARNING, "Unknown DHCPv6 message type %d\n", msg->msg_type);
         return;
     }

--- a/src/relay.cpp
+++ b/src/relay.cpp
@@ -755,7 +755,7 @@ void callback_dual_tor(evutil_socket_t fd, short event, void *arg) {
         current_position = tmp;
 
         if (current_position + sizeof(struct dhcpv6_msg) > ((uint8_t *)ptr + buffer_sz)) {
-            syslog(LOG_WARNING, "Invalid DHCPv6 packet length %d, no space for dhcpv6 msg header\n", buffer_sz);
+            syslog(LOG_WARNING, "Invalid DHCPv6 packet length %ld, no space for dhcpv6 msg header\n", buffer_sz);
             return;
         }
         auto msg = parse_dhcpv6_hdr(current_position);
@@ -829,6 +829,7 @@ void server_callback(evutil_socket_t fd, short event, void *arg) {
     socklen_t len = sizeof(from);
     int32_t data = 0;
     static uint8_t message_buffer[BUFFER_SIZE];
+    std::string counterVlan = counter_table;
 
     if ((data = recvfrom(config->local_sock, message_buffer, BUFFER_SIZE, 0, (sockaddr *)&from, &len)) == -1) {
         syslog(LOG_ERR, "recv: Failed to receive data from server\n");
@@ -850,7 +851,7 @@ void server_callback(evutil_socket_t fd, short event, void *arg) {
     else {
         counters[msg->msg_type]++;
     }
-    std::string counterVlan = counter_table;
+
     update_counter(config->state_db, counterVlan.append(config->interface), msg->msg_type);
     if (msg->msg_type == DHCPv6_MESSAGE_TYPE_RELAY_REPL) {
         relay_relay_reply(config->server_sock, message_buffer, data, config);

--- a/src/relay.h
+++ b/src/relay.h
@@ -394,15 +394,3 @@ void callback_dual_tor(evutil_socket_t fd, short event, void *arg);
  */
 void server_callback(evutil_socket_t fd, short event, void *arg);
 
-/**
- * @code                void server_callback_dual_tor(evutil_socket_t fd, short event, void *arg);
- * 
- * @brief               callback for libevent that is called everytime data is received at the server socket
- *
- * @param fd            filter socket
- * @param event         libevent triggered event  
- * @param arg           callback argument provided by user
- *
- * @return              none
- */
-void server_callback_dual_tor(evutil_socket_t fd, short event, void *arg);


### PR DESCRIPTION
Why I did it
Fix packet range check issue in introduced by https://github.com/sonic-net/sonic-dhcp-relay/pull/19
Update unknown counter on packet discarded by msg_type range check
Remove unneeded server_callback_dual_tor which is a duplicate of server_callback

How to verify it
Manually ran unittest and mgmt test

