### PR TITLE
Log updated to print useful info during send_udp failure

### DIFF
--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -1,5 +1,8 @@
 #include "sender.h"
 #include <syslog.h>
+#include <errno.h>
+#include <cstring>
+#include <arpa/inet.h>
 
 /**
  * @code                            bool send_udp(int sock, uint8_t *buffer, struct sockaddr_in6 target, uint32_t n);
@@ -16,7 +19,9 @@
  */
 bool send_udp(int sock, uint8_t *buffer, struct sockaddr_in6 target, uint32_t n) {
     if(sendto(sock, buffer, n, 0, (const struct sockaddr *)&target, sizeof(target)) == -1) {
-        syslog(LOG_ERR, "sendto: Failed to send to target address\n");
+        char server_addr[INET6_ADDRSTRLEN];
+        inet_ntop(AF_INET6, &(target.sin6_addr), server_addr, INET6_ADDRSTRLEN);
+        syslog(LOG_ERR, "sendto: Failed to send to target address: %s, error: %s\n", server_addr, strerror(errno));
         return false;
     }
     return true;


### PR DESCRIPTION
Signed-off-by: Vivek Reddy <vkarri@nvidia.com>

Previously:
```
"Nov 22 01:16:52.810771 sonic ERR dhcp_relay#dhcp6relay: sendto: Failed to send to target address"
```

Updated Log:
``` 
Nov 22 07:57:27.992323 sonic ERR dhcp_relay#dhcp6relay: sendto: Failed to send to target address: 6900::2, error: Network is unreachable
```
