### PR TITLE
disable relay configuration dynamic change

### DIFF
--- a/src/configInterface.h
+++ b/src/configInterface.h
@@ -28,13 +28,13 @@ void initialize_swss(std::vector<relay_config> *vlans);
 void deinitialize_swss();
 
 /**
- * @code                void get_dhcp(std::vector<relay_config> *vlans)
+ * @code                void get_dhcp(std::vector<relay_config> *vlans, swss::SubscriberStateTable *ipHelpersTable, bool dynamic)
  * 
  * @brief               initialize and get vlan information from DHCP_RELAY
  *
  * @return              none
  */
-void get_dhcp(std::vector<relay_config> *vlans, swss::SubscriberStateTable *ipHelpersTable);
+void get_dhcp(std::vector<relay_config> *vlans, swss::SubscriberStateTable *ipHelpersTable, bool dynamic);
 
 /**
  * @code                void swssNotification test


### PR DESCRIPTION
#### Why I did it
disable dhcp relay configuration dynamic change, since current code not ready for that.

fix issue
https://github.com/sonic-net/sonic-buildimage/issues/12496

#### How I did it
1. Instead of applying new configuration, we will give a warning message when configuration change detected after container bootup. User need manually restart container to take effect. 
2. still keep config monitor thread as in future we may reopen it after resolve dynamic config change issue 

#### How to verify it
Verify by script for regression, and UT with check syslog after configuration change.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

