### PR TITLE
fix handleSwssNotification crash in dhcp6relay

### DIFF
--- a/src/configInterface.cpp
+++ b/src/configInterface.cpp
@@ -23,10 +23,6 @@ void initialize_swss(std::vector<relay_config> *vlans)
         swss::SubscriberStateTable ipHelpersTable(configDbPtr.get(), "DHCP_RELAY");
         swssSelect.addSelectable(&ipHelpersTable);
         get_dhcp(vlans, &ipHelpersTable, false);
-        struct swssNotification test;
-        test.vlans = vlans;
-        test.ipHelpersTable = &ipHelpersTable;
-        mSwssThreadPtr = std::make_shared<boost::thread> (&handleSwssNotification, test);
     }
     catch (const std::bad_alloc &e) {
         syslog(LOG_ERR, "Failed allocate memory. Exception details: %s", e.what());


### PR DESCRIPTION
Description:

Latest dhcp code meet an crash when doing port channel interface shut/noshut.

Remove related swss notification call back, since we don't support configuration dynamic change in current code.

UT:
test_dhcpv6_relay.py::test_dhcp_relay_after_link_flap is able to cover this by running multiple times.