### PR TITLE
fix relay-reply dhcpv6 packet counter issue

### DIFF
--- a/src/relay.cpp
+++ b/src/relay.cpp
@@ -567,9 +567,6 @@ void relay_relay_forw(int sock, const uint8_t *msg, int32_t len, const ip6_hdr *
     auto dhcp_relay_header = parse_dhcpv6_relay(msg);
     current_position += sizeof(struct dhcpv6_relay_msg);
 
-    auto position = current_position + sizeof(struct dhcpv6_option);
-    auto dhcpv6msg = parse_dhcpv6_hdr(position);
-
     while ((current_position - msg) < len) {
         auto option = parse_dhcpv6_opt(current_position, &tmp);
         current_position = tmp;
@@ -577,11 +574,13 @@ void relay_relay_forw(int sock, const uint8_t *msg, int32_t len, const ip6_hdr *
             break;
         }
         switch (ntohs(option->option_code)) {
-            case OPTION_RELAY_MSG:
-                memcpy(current_buffer_position, ((uint8_t *)option) + sizeof(struct dhcpv6_option), ntohs(option->option_length));
+            case OPTION_RELAY_MSG: {
+                uint8_t *dhcpv6_position = ((uint8_t *)option) + sizeof(struct dhcpv6_option);
+                type = parse_dhcpv6_hdr(dhcpv6_position)->msg_type;
+                memcpy(current_buffer_position, dhcpv6_position, ntohs(option->option_length));
                 current_buffer_position += ntohs(option->option_length);
-                type = dhcpv6msg->msg_type;
                 break;
+            }
             default:
                 break;
         }


### PR DESCRIPTION
#### Why I did it
fix issue https://github.com/sonic-net/sonic-buildimage/issues/13083

#### How I did it
DHCPv6 Relay-Reply packet decode issue, original code assume Relay Message option (option 9) was the first option in Relay-Reply .
If other options exists before option9, DHCPv6 message type inside Relay-Msg will wrong. 

#### How to verify it
Enhance sonic-mgmt dhcpv6_cpunter_test.py, use different format of Relay-Reply packets.
Test case improve:
https://github.com/sonic-net/sonic-mgmt/pull/7105

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205 
