### PR TITLE
Broken show dhcp6relay_counters output fixed

### DIFF
--- a/src/relay.cpp
+++ b/src/relay.cpp
@@ -917,9 +917,9 @@ void server_callback(evutil_socket_t fd, short event, void *arg) {
     sockaddr_in6 from;
     socklen_t len = sizeof(from);
     int32_t pkts_num = 0;
-    std::string counterVlan = counter_table;
 
     while (pkts_num++ < BATCH_SIZE) {
+        std::string counterVlan = counter_table;
         auto buffer_sz = recvfrom(config->local_sock, server_recv_buffer, BUFFER_SIZE, 0, (sockaddr *)&from, &len);
         if (buffer_sz <= 0) {
             if (errno != EAGAIN) {


### PR DESCRIPTION
When there are multiple DHCPv6 clients, and all the relay-reply requests are processed at once in the server callback, the dhcpv6 counters table is not updated properly

Eg: 

```
root@qa-eth-vt03-3-4600ca1:/home/admin# show dhcp6relay_counters counts 
       Message Type    Vlan10
-------------------  --------
            Unknown         0
            Solicit         4
          Advertise         4
            Request         4
            Confirm         0
              Renew         0
             Rebind         0
              Reply         8
            Release         4
            Decline         0
        Reconfigure         0
Information-Request         0
      Relay-Forward        12
        Relay-Reply         9
          Malformed         0

       Message Type    Vlan10Vlan10
-------------------  --------------
            Unknown
            Solicit
          Advertise
            Request
            Confirm
              Renew
             Rebind
              Reply
            Release
            Decline
        Reconfigure
Information-Request
      Relay-Forward
        Relay-Reply              10
          Malformed


       Message Type    Vlan10Vlan10Vlan10
-------------------  --------------------
            Unknown
            Solicit
          Advertise
            Request
            Confirm
              Renew
             Rebind
              Reply
            Release
            Decline
        Reconfigure
Information-Request
      Relay-Forward
        Relay-Reply                    11
          Malformed

       Message Type    Vlan10Vlan10Vlan10Vlan10
-------------------  --------------------------
            Unknown
            Solicit
          Advertise
            Request
            Confirm
              Renew
             Rebind
              Reply
            Release
            Decline
        Reconfigure
Information-Request
      Relay-Forward
        Relay-Reply                          12
          Malformed


```