### PR TITLE
Switch to using the current swss-common artifacts

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -84,8 +84,7 @@ jobs:
         artifact: sonic-swss-common
       ${{ else }}:
         artifact: sonic-swss-common.${{ parameters.arch }}
-      runVersion: 'specific'
-      runId: 128696
+      runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/master'
       path: '$(Build.SourcesDirectory)/sonic-swss-common'
     displayName: "Download sonic swss common deb packages"


### PR DESCRIPTION
The swss-common pipeline is now built for Bullseye.