### PR TITLE
fix dhcpv6 counters are not cleared on clear command

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - 'master'
       - '202[0-9][0-9][0-9]'
-  pull_request_target:
+  pull_request:
     branches:
       - 'master'
       - '202[0-9][0-9][0-9]'
@@ -57,6 +57,13 @@ jobs:
             libyang-dev \
             libpython2.7-dev \
             python
+
+    - name: reset-submodules
+      run: |
+        git submodule foreach --recursive 'git clean -xfdf || true'
+        git submodule foreach --recursive 'git reset --hard || true'
+        git submodule foreach --recursive 'git remote update || true'
+        git submodule update --init --recursive
 
     - name: build-swss-common
       run: |

--- a/src/relay.h
+++ b/src/relay.h
@@ -288,29 +288,29 @@ void signal_callback(evutil_socket_t fd, short event, void *arg);
 void shutdown_relay();
 
 /**
- * @code                void initialize_counter(std::shared_ptr<swss::Table> state_db, std::string counterVlan);
+ * @code                void initialize_counter(std::shared_ptr<swss::Table> state_db, std::string &ifname);
  *
- * @brief               initialize the counter by each Vlan
+ * @brief               initialize the counter for interface
  *
  * @param std::shared_ptr<swss::Table> state_db     state_db connector
- * @param counterVlan   counter table with interface name
+ * @param ifname        interface name
  * 
  * @return              none
  */
-void initialize_counter(std::shared_ptr<swss::DBConnector> state_db, std::string counterVlan);
+void initialize_counter(std::shared_ptr<swss::DBConnector> state_db, std::string &ifname);
 
 /**
- * @code                void increase_counter(shared_ptr<swss::DBConnector>, std::string CounterVlan, uint8_t msg_type);
+ * @code                void increase_counter(shared_ptr<swss::DBConnector>, std::string ifname, uint8_t msg_type);
  *
  * @brief               increase the counter in state_db with count of each DHCPv6 message type
  *
  * @param shared_ptr<swss::DBConnector> state_db     state_db connector
- * @param counterVlan   counter table with interface name
+ * @param ifname        interface name
  * @param msg_type      dhcpv6 message type to be increased in counter
  * 
  * @return              none
  */
-void increase_counter(std::shared_ptr<swss::DBConnector> state_db, std::string counterVlan, uint8_t msg_type);
+void increase_counter(std::shared_ptr<swss::DBConnector> state_db, std::string &ifname, uint8_t msg_type);
 
 /* Helper functions */
 

--- a/test/mock_relay.cpp
+++ b/test/mock_relay.cpp
@@ -296,7 +296,8 @@ TEST(prepareConfig, prepare_socket)
 TEST(counter, initialize_counter)
 {
   std::shared_ptr<swss::DBConnector> state_db = std::make_shared<swss::DBConnector> ("STATE_DB", 0);
-  initialize_counter(state_db, "DHCPv6_COUNTER_TABLE|Vlan1000");
+  std::string ifname = "Vlan1000";
+  initialize_counter(state_db, ifname);
   EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Unknown"));
   EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Solicit"));
   EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Advertise"));
@@ -315,7 +316,8 @@ TEST(counter, increase_counter)
 {
   std::shared_ptr<swss::DBConnector> state_db = std::make_shared<swss::DBConnector> ("STATE_DB", 0);
   state_db->hset("DHCPv6_COUNTER_TABLE|Vlan1000", "Solicit", "0");
-  increase_counter(state_db, "DHCPv6_COUNTER_TABLE|Vlan1000", 1);
+  std::string ifname = "Vlan1000";
+  increase_counter(state_db, ifname, 1);
   std::shared_ptr<std::string> output = state_db->hget("DHCPv6_COUNTER_TABLE|Vlan1000", "Solicit");
   std::string *ptr = output.get();
   EXPECT_EQ(*ptr, "1");
@@ -632,7 +634,8 @@ TEST(relay, update_vlan_mapping) {
 
 TEST(relay, client_packet_handler) {
   std::shared_ptr<swss::DBConnector> state_db = std::make_shared<swss::DBConnector> ("STATE_DB", 0);
-  initialize_counter(state_db, "DHCPv6_COUNTER_TABLE|Vlan1000");
+  std::string vlan_name = "Vlan1000";
+  initialize_counter(state_db, vlan_name);
 
   struct relay_config config{};
   config.is_option_79 = true;
@@ -707,7 +710,8 @@ MOCK_GLOBAL_FUNC6(recvfrom, ssize_t(int, void *, size_t, int, struct sockaddr *,
 
 TEST(relay, server_callback) {
   std::shared_ptr<swss::DBConnector> state_db = std::make_shared<swss::DBConnector> ("STATE_DB", 0);
-  initialize_counter(state_db, "DHCPv6_COUNTER_TABLE|Vlan1000");
+  std::string ifname = "Vlan1000";
+  initialize_counter(state_db, ifname);
 
   struct relay_config config{};
   config.is_option_79 = true;
@@ -738,7 +742,8 @@ TEST(relay, client_callback) {
   std::shared_ptr<swss::Table> mux_table = std::make_shared<swss::Table> (
         state_db.get(), "HW_MUX_CABLE_TABLE"
   );
-  initialize_counter(state_db, "DHCPv6_COUNTER_TABLE|Vlan1000");
+  std::string ifname = "Vlan1000";
+  initialize_counter(state_db, ifname);
 
   struct relay_config config{};
   config.is_option_79 = true;


### PR DESCRIPTION
### Description of PR
Fix dhcpv6 counters are not cleared after "clear dhcp6relay_counters", or "sonic-db-cli STATE_DB hmset "DHCPv6_COUNTER_TABLE|Vlan1000" {} 0
 
Summary:
Fix https://github.com/sonic-net/sonic-buildimage/issues/14447
dhcpv6 relay counter cached in original relay code, so even we clear counter in STATE_DB, next time when packets come from downlink or uplink ports, counter will be flushed with relay cached data + 1, so the counter flushed back to original data + 1. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
Need in 202205 and 202012, need manually double commit because of code conflict. 

### Approach
#### What is the motivation for this PR?
Fix clear counter issue

#### How did you do it?
Remove cache in dhcp_relay code, instead we will read count from STATE_DB then refresh.

#### How did you verify/test it?
test_dhcpv6_relay.py::test_dhcpv6_relay_counter multiple times and with clear counter.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?