### PR TITLE
[master]fix dhcpv6 relay dual tor source interface selection issue

### DIFF
--- a/src/config_interface.cpp
+++ b/src/config_interface.cpp
@@ -108,6 +108,12 @@ void handleRelayNotification(swss::SubscriberStateTable &ipHelpersTable, std::un
 void processRelayNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries, std::unordered_map<std::string, relay_config> &vlans)
 {
     std::vector<std::string> servers;
+    bool option_79_default = true;
+    bool interface_id_default = false;
+
+    if (dual_tor_sock) {
+        interface_id_default = true;
+    }
 
     for (auto &entry: entries) {
         std::string vlan = kfvKey(entry);
@@ -115,8 +121,8 @@ void processRelayNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries,
         std::vector<swss::FieldValueTuple> fieldValues = kfvFieldsValues(entry);
 
         relay_config intf;
-        intf.is_option_79 = true;
-        intf.is_interface_id = false;
+        intf.is_option_79 = option_79_default;
+        intf.is_interface_id = interface_id_default;
         intf.interface = vlan;
         intf.mux_key = "";
         intf.state_db = nullptr;

--- a/src/config_interface.h
+++ b/src/config_interface.h
@@ -7,10 +7,13 @@
 #include "select.h"
 #include "relay.h"
 
+extern bool dual_tor_sock;
+
 struct swssNotification {
     std::unordered_map<std::string, relay_config> vlans;
     swss::SubscriberStateTable *ipHelpersTable;
 };
+
 /**
  * @code                void initialize_swss()
  * 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,23 +4,32 @@
 #include "config_interface.h"
 
 bool dual_tor_sock = false;
+char loopback[IF_NAMESIZE] = "Loopback0";
 
 static void usage()
 {
-    printf("Usage: ./dhcp6relay {-d}\n");
-    printf("\t-d: enable dual tor option\n");
+    printf("Usage: ./dhcp6relay [-u <loopback interface>]\n");
+    printf("\tloopback interface: is the loopback interface for dual tor setup\n");
 }
 
 int main(int argc, char *argv[]) {
-    if (argc > 1) {
+    if (argc > 2) {
         switch (argv[1][1])
         {
-            case 'd':
+            case 'u':
+                if (strlen(argv[2]) != 0 && strlen(argv[2]) < IF_NAMESIZE) {
+                    std::memset(loopback, 0, IF_NAMESIZE);
+                    std::memcpy(loopback, argv[2], strlen(argv[2]));
+                } else {
+                    syslog(LOG_ERR, "loopback interface name over length %d.\n", IF_NAMESIZE);
+                    return 1;
+                }
                 dual_tor_sock = true;
                 break;
             default:
                 fprintf(stderr, "%s: Unknown option\n", basename(argv[0]));
                 usage();
+                return 0;
         }
     }
     try {

--- a/test/mock_relay.h
+++ b/test/mock_relay.h
@@ -12,3 +12,4 @@ extern struct event_base *base;
 extern struct event *ev_sigint;
 extern struct event *ev_sigterm;
 extern std::unordered_map<std::string, std::string> vlan_map;
+extern std::unordered_map<std::string, std::string> addr_vlan_map;


### PR DESCRIPTION
### Description of PR
[master] Fix DHCPv6 relay dual-tor relay-reply handling issue. 

Other related docker change PR:
https://github.com/sonic-net/sonic-buildimage/pull/15744/files

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix DHCPv6 relay dual-tor relay-reply handling issue. In dual-tor scenario, we need responses from dhcpv6 server send to Active tor. Based on RFC8415 session [18.3.10], DHCPv6 server unicasts the Relay-reply message directly to the relay agent using the address in the source address field from the IP datagram in which the Relay-forward message was received. So in dual-tor we need use DUT unique loopback ipv6 address as relay-forward source (Vlan IPv6 is same on both active tor and standby tor).

Main changed in this PR:
1.  Use loopback0 as relay-forward source interface, create loopback0 socket for packet sending and listening 
2.  Fix multiple level relay agent case: Relay-Reply send to next level relay agent will use GUA instead of LLA as source address, and dest port should use 547 
3.  Multiple level relay-forward will insert option18 to carry vlan information, and relay agent will get vlan info from response to update counters in this case.
4. Code cleanup after apply latest code change  

#### How did you do it?

#### How did you verify/test it?
single-tor sanity testing no issue
dual-tor function test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
