### PR TITLE
[counter] Clear counter table when dhcp6relay init

### DIFF
--- a/src/relay.h
+++ b/src/relay.h
@@ -559,3 +559,13 @@ void packet_counting_handler(uint8_t *buffer, ssize_t length, std::string &ifnam
  * 
  */
 void prepare_socket_callback(event_base *base, int socket, void (*cb)(evutil_socket_t, short, void *), void *arg);
+
+/**
+ * @code clear_counter(std::shared_ptr<swss::DBConnector> state_db);
+ * 
+ * @brief Clear all counter
+ * 
+ * @param state_db      state_db connector pointer
+ * 
+ */
+void clear_counter(std::shared_ptr<swss::DBConnector> state_db);

--- a/test/mock_relay.cpp
+++ b/test/mock_relay.cpp
@@ -325,6 +325,17 @@ TEST(counter, initialize_counter)
   EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "TX"));
 }
 
+TEST(counter, clear_counter)
+{
+  std::shared_ptr<swss::DBConnector> state_db = std::make_shared<swss::DBConnector> ("STATE_DB", 0);
+  std::string ifname = "Vlan1000";
+  initialize_counter(state_db, ifname);
+  EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "RX"));
+  EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "TX"));
+  clear_counter(state_db);
+  EXPECT_FALSE(state_db->exists("DHCPv6_COUNTER_TABLE|Vlan1000"));
+}
+
 TEST(counter, increase_counter)
 {
   std::shared_ptr<swss::DBConnector> state_db = std::make_shared<swss::DBConnector> ("STATE_DB", 0);


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix issue https://github.com/sonic-net/sonic-buildimage/issues/15047
dhcpv6 counter didn't restore after config reload

##### Work item tracking
- Microsoft ADO **(number only)**: 26065484

#### How I did it
1. Clear all counters when dhcp6relay start and add related ut
2. Remove clear counter in `initialize_counter` since they are cleared in previous

#### How to verify it
1. UT passed
2. Build debian packet and install in DUT do manually testing
3. Run dhcp_relay test, all passed
```
============================= test session starts ==============================
platform linux -- Python 3.8.10, pytest-7.1.3, pluggy-1.2.0
ansible: 2.9.27
rootdir: /var/src/sonic-mgmt-int/tests, configfile: pytest.ini
plugins: html-3.2.0, forked-1.6.0, ansible-3.1.5, xdist-1.28.0, allure-pytest-2.8.22, repeat-0.9.1, metadata-3.0.0
collected 22 items

dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo0] PASSED [  4%]
dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo1] PASSED [  9%]
dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo2] PASSED [ 13%]
dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo3] PASSED [ 18%]
dhcp_relay/test_dhcp_relay.py::test_interface_binding PASSED             [ 22%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default[single] PASSED    [ 27%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap[single] PASSED [ 31%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_start_with_uplinks_down[single] PASSED [ 36%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac[single] PASSED [ 40%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport[single] PASSED [ 45%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter[single] PASSED    [ 50%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default[dual] SKIPPED     [ 54%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap[dual] SKIPPED [ 59%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_start_with_uplinks_down[dual] SKIPPED [ 63%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac[dual] SKIPPED [ 68%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport[dual] SKIPPED [ 72%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter[dual] SKIPPED     [ 77%]
dhcp_relay/test_dhcpv6_relay.py::test_interface_binding PASSED           [ 81%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter PASSED        [ 86%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_default PASSED          [ 90%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_after_link_flap PASSED  [ 95%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_start_with_uplinks_down PASSED [100%]INFO:root:Can not get Allure report URL. Please check logs
```