### PR TITLE
Skip vlan if it has no dhcpv6 servers configured

### DIFF
--- a/src/config_interface.cpp
+++ b/src/config_interface.cpp
@@ -145,6 +145,10 @@ void processRelayNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries,
                 intf.is_interface_id = true;
             }
         }
+        if (intf.servers.empty()) {
+            syslog(LOG_WARNING, "No servers found for VLAN %s, skipping configuration.", vlan.c_str());
+            continue;
+        }
         syslog(LOG_INFO, "add %s relay config, option79 %s interface-id %s\n", vlan.c_str(),
                intf.is_option_79 ? "enable" : "disable", intf.is_interface_id ? "enable" : "disable");
         vlans[vlan] = intf;


### PR DESCRIPTION
#### Why I did it
When not all vlans have dhcpv6 servers configured, dhcp6relay fails to start because it expects all vlans under DHCP_RELAY table to have dhcpv6 server configured.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Skip adding vlan to dhcp6relay if no dhcpv6 servers are configured

#### How to verify it
Tested by configuring DHCP_RELAY|Vlan200 to NULL values and configuring dhcpv6 servers for DHCP_RELAY|Vlan100. Dhcp6relay will only open sockets for Vlan100 and not Vlan200

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

