### PR TITLE
Clear counter when dhcp6relay init

### DIFF
--- a/src/relay.cpp
+++ b/src/relay.cpp
@@ -271,6 +271,7 @@ bool DHCPv6Msg::UnmarshalBinary(const uint8_t *packet, uint16_t len) {
  * @return              none
  */
 void initialize_counter(std::shared_ptr<swss::DBConnector> state_db, std::string &ifname) {
+    clear_counter(state_db);
     std::string table_name = counter_table + ifname;
     for (auto &intr : counterMap) {
         state_db->hset(table_name, intr.second, toString(0)); 
@@ -1333,4 +1334,20 @@ void shutdown_relay() {
     event_free(ev_sigterm);
     event_base_free(base);
     deinitialize_swss();
+}
+
+/**
+ * @code clear_counter(std::shared_ptr<swss::DBConnector> state_db);
+ * 
+ * @brief Clear all counter
+ * 
+ * @param state_db      state_db connector pointer
+ * 
+ */
+void clear_counter(std::shared_ptr<swss::DBConnector> state_db) {
+    std::string match_pattern = counter_table + std::string("*");
+    auto keys = state_db->keys(match_pattern);
+    for (auto &itr : keys) {
+        state_db->del(itr);
+    }
 }

--- a/src/relay.h
+++ b/src/relay.h
@@ -474,3 +474,12 @@ void client_packet_handler(uint8_t *buffer, ssize_t length, struct relay_config 
  */
 void server_callback(evutil_socket_t fd, short event, void *arg);
 
+/**
+ * @code clear_counter(std::shared_ptr<swss::DBConnector> state_db);
+ * 
+ * @brief Clear all counter
+ * 
+ * @param state_db      state_db connector pointer
+ * 
+ */
+void clear_counter(std::shared_ptr<swss::DBConnector> state_db);

--- a/test/mock_relay.cpp
+++ b/test/mock_relay.cpp
@@ -350,9 +350,31 @@ TEST(counter, clear_counter)
   std::shared_ptr<swss::DBConnector> state_db = std::make_shared<swss::DBConnector> ("STATE_DB", 0);
   std::string ifname = "Vlan1000";
   initialize_counter(state_db, ifname);
-  EXPECT_FALSE(state_db->exists("DHCPv6_COUNTER_TABLE|Vlan1000"));
+  EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Unknown"));
+  EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Solicit"));
+  EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Advertise"));
+  EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Request"));
+  EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Confirm"));
+  EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Renew"));
+  EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Rebind"));
+  EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Reply"));
+  EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Release"));
+  EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Decline"));
+  EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Relay-Forward"));
+  EXPECT_TRUE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Relay-Reply"));
   clear_counter(state_db);
-  EXPECT_FALSE(state_db->exists("DHCPv6_COUNTER_TABLE|Vlan1000"));
+  EXPECT_FALSE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Unknown"));
+  EXPECT_FALSE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Solicit"));
+  EXPECT_FALSE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Advertise"));
+  EXPECT_FALSE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Request"));
+  EXPECT_FALSE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Confirm"));
+  EXPECT_FALSE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Renew"));
+  EXPECT_FALSE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Rebind"));
+  EXPECT_FALSE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Reply"));
+  EXPECT_FALSE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Release"));
+  EXPECT_FALSE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Decline"));
+  EXPECT_FALSE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Relay-Forward"));
+  EXPECT_FALSE(state_db->hexists("DHCPv6_COUNTER_TABLE|Vlan1000", "Relay-Reply"));
 }
 
 TEST(relay, relay_client) 

--- a/test/mock_relay.cpp
+++ b/test/mock_relay.cpp
@@ -345,6 +345,16 @@ TEST(counter, increase_counter)
   EXPECT_EQ(*ptr, "1");
 }
 
+TEST(counter, clear_counter)
+{
+  std::shared_ptr<swss::DBConnector> state_db = std::make_shared<swss::DBConnector> ("STATE_DB", 0);
+  std::string ifname = "Vlan1000";
+  initialize_counter(state_db, ifname);
+  EXPECT_FALSE(state_db->exists("DHCPv6_COUNTER_TABLE|Vlan1000"));
+  clear_counter(state_db);
+  EXPECT_FALSE(state_db->exists("DHCPv6_COUNTER_TABLE|Vlan1000"));
+}
+
 TEST(relay, relay_client) 
 {
   uint8_t msg[] = {


### PR DESCRIPTION
Fix issue https://github.com/sonic-net/sonic-buildimage/issues/15047

### Why I did it
When dhcp6relay startup, it would clear and reset the counter in `DHCP_RELAY` table, and it would cause that counter data of deleted Vlan wouldn't be clear.

### How I did it
Clear all counter when dhcp6relay init

### How I verify it
1. UT
2. Install new dhcp6relay in testbed 
2.1. Add Vlan2000,
2.2. Send dhcpv6 packets to Vlan2000, confirm that counter has been updated
2.3 reload config without Vlan2000, confirm that counter data of Vlan2000 has been deleted
```
admin@bjw-can-2700-3:~$ sonic-db-cli STATE_DB hgetall "DHCPv6_COUNTER_TABLE|Vlan1000"
{'Unknown': '0', 'Solicit': '1', 'Advertise': '0', 'Request': '0', 'Confirm': '0', 'Renew': '0', 'Rebind': '0', 'Reply': '0', 'Release': '0', 'Decline': '0', 'Reconfigure': '0', 'Information-Request': '0', 'Relay-Forward': '4', 'Relay-Reply': '0', 'Malformed': '0'}
admin@bjw-can-2700-3:~$ sonic-db-cli STATE_DB hgetall "DHCPv6_COUNTER_TABLE|Vlan2000"
{'Unknown': '0', 'Solicit': '3', 'Advertise': '0', 'Request': '0', 'Confirm': '0', 'Renew': '0', 'Rebind': '0', 'Reply': '0', 'Release': '0', 'Decline': '0', 'Reconfigure': '0', 'Information-Request': '0', 'Relay-Forward': '3', 'Relay-Reply': '0', 'Malformed': '0'}
admin@bjw-can-2700-3:~$ sudo config reload -y
Acquired lock on /etc/sonic/reload.lock
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db.json --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Restarting SONiC target ...
Enabling container monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon
Released lock on /etc/sonic/reload.lock
admin@bjw-can-2700-3:~$ sonic-db-cli STATE_DB hgetall "DHCPv6_COUNTER_TABLE|Vlan1000"
{'Unknown': '0', 'Solicit': '0', 'Advertise': '0', 'Request': '0', 'Confirm': '0', 'Renew': '0', 'Rebind': '0', 'Reply': '0', 'Release': '0', 'Decline': '0', 'Reconfigure': '0', 'Information-Request': '0', 'Relay-Forward': '0', 'Relay-Reply': '0', 'Malformed': '0'}
admin@bjw-can-2700-3:~$ sonic-db-cli STATE_DB hgetall "DHCPv6_COUNTER_TABLE|Vlan2000"
{}
admin@bjw-can-2700-3:~$ 
```