### PR TITLE
Fail build in PR check when UT fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ $(DHCP6RELAY_TEST_TARGET): $(TEST_OBJS)
 	$(CXX) $(LDFLAGS) $^ $(LDLIBS) $(LDLIBS_TEST) -o $@
 
 test: $(DHCP6RELAY_TEST_TARGET)
-	sudo ASAN_OPTIONS=detect_leaks=0 ./$(DHCP6RELAY_TEST_TARGET) --gtest_output=xml:$(DHCP6RELAY_TEST_TARGET)-test-result.xml || true
+	sudo ASAN_OPTIONS=detect_leaks=0 ./$(DHCP6RELAY_TEST_TARGET) --gtest_output=xml:$(DHCP6RELAY_TEST_TARGET)-test-result.xml || { echo 'Tests failed'; exit 1; }
 	$(GCOVR) -r ./ --html --html-details -o $(DHCP6RELAY_TEST_TARGET)-code-coverage.html
 	$(GCOVR) -r ./ --xml-pretty -o $(DHCP6RELAY_TEST_TARGET)-code-coverage.xml
 


### PR DESCRIPTION
#### Why I did it
In current PR check, we would build dhcp6relay debian package, but even if the unit test failed, the build would still be ongoing, then the PR check would pass. It would cause we miss some unexpected damage change
![image](https://github.com/user-attachments/assets/e31cac83-f7c9-4d10-9426-53ca17c7cfe5)

#### How I did it
Modify Makefile to exit with code 1 if test fail

#### How I verify it
PR check