### PR TITLE
Allow using Boost 1.83 for compilation

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -22,12 +22,12 @@ jobs:
   steps:
   - ${{ if and(eq(parameters.arch, 'amd64'), parameters.codeCoverage) }}:
     - script: |
-        wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+        wget https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
         sudo dpkg -i packages-microsoft-prod.deb
         rm packages-microsoft-prod.deb
         sudo apt-get update
         sudo apt-get install -y apt-transport-https
-        sudo apt-get install -y dotnet-sdk-6.0
+        sudo apt-get install -y dotnet-sdk-8.0
       displayName: install .Net
   - script: |
       set -ex

--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -22,7 +22,7 @@ jobs:
   steps:
   - ${{ if and(eq(parameters.arch, 'amd64'), parameters.codeCoverage) }}:
     - script: |
-        wget https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+        wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
         sudo dpkg -i packages-microsoft-prod.deb
         rm packages-microsoft-prod.deb
         sudo apt-get update
@@ -73,8 +73,8 @@ jobs:
       ${{ else }}:
         artifact: common-lib.${{ parameters.arch }}
       patterns: |
-        target/debs/bookworm/libyang-*.deb
-        target/debs/bookworm/libyang_*.deb
+        target/debs/bookworm/libyang-*_1.0*.deb
+        target/debs/bookworm/libyang_1.0*.deb
     displayName: "Download libyang from common lib"
   - script: |
       set -ex

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: sonic-dhcp6relay
 Section: devel
 Priority: optional
 Maintainer: Kelly Yeh <kellyyeh@microsoft.com>
-Build-Depends: debhelper (>= 12.0.0), libevent-dev, libboost-thread-dev, libboost-system-dev, libswsscommon-dev
+Build-Depends: debhelper (>= 12.0.0), libevent-dev, libboost-thread-dev | libboost-thread1.83-dev, libboost-system-dev | libboost-system1.83-dev, libswsscommon-dev
 Standards-Version: 3.9.3
 Homepage: https://github.com/Azure/sonic-buildimage
 XS-Go-Import-Path: github.com/Azure/sonic-buildimage


### PR DESCRIPTION
With the base image upgrade to Trixie, Bookworm-based containers will need to use Boost 1.83. This is because of an incompatibility between rsyslog_plugin that uses Boost 1.83 on Trixie and the eventd container that uses Boost 1.74 on Bookworm; specifically there is an incompatiblity with serialization of objects between the two versions of Boost.

Because of this, allow applications to compile with Boost 1.83 headers.