### PR TITLE
changes did to pick the primary ip from vlan

### DIFF
--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -373,10 +373,18 @@ int prepare_vlan_sockets(relay_config &config) {
                 if (ifa_tmp->ifa_addr && (ifa_tmp->ifa_addr->sa_family == AF_INET)) {
                     if (strcmp(ifa_tmp->ifa_name, config.vlan.c_str()) == 0) {
                         struct sockaddr_in *in = (struct sockaddr_in *)ifa_tmp->ifa_addr;
-                        bind_client_addr = true;
-                        client_addr = *in;
-                        client_addr.sin_family = AF_INET;
-                        client_addr.sin_port = htons(RELAY_PORT);
+                        char ip_str[INET_ADDRSTRLEN];
+                        inet_ntop(AF_INET, &(in->sin_addr), ip_str, INET_ADDRSTRLEN);
+                        std::string value;
+                        std::shared_ptr<swss::Table> vlan_intf_tbl = std::make_shared<swss::Table>(config_db.get(), CFG_VLAN_INTF_TABLE_NAME);
+                        vlan_intf_tbl->hget((config.vlan + "|" + ip_str), "secondary", value);
+                        if ((value.size() == 0) || (value != "true")) {
+                            bind_client_addr = true;
+                            client_addr = *in;
+                            client_addr.sin_family = AF_INET;
+                            client_addr.sin_port = htons(RELAY_PORT);
+                            break;
+                        }
                     }
                 }
                 ifa_tmp = ifa_tmp->ifa_next;


### PR DESCRIPTION
root cause: The sonic-mgmt testcase fails because the source IP address in the DHCP Offer packet relayed back to the client is wrong.Everything else in the packet matches (or is masked as don't-care). The only mismatch is the source IP: 192.168.0.1 vs 192.169.0.1 

Vlan1000 has two IPv4 addresses:
192.168.0.1/21 (primary)
192.169.0.1/22 (secondary)
The full test flow in runTest is:
Client sends Discover → relay forwards to servers (with giaddr=192.168.0.1)
verify_relayed_discover() — PASSES (relay correctly relayed the Discover)
Server (PTF) sends Offer back to relay with dst=192.168.0.1, giaddr=192.168.0.1
verify_offer_received() — FAILS (relay forwarded the Offer to client with src=192.169.0.1 instead of src=192.168.0.1)
Importantly, the test output shows 1 passed, 1 failed — the passed test is likely test_dhcp_relay_default which runs the same packet verification logic. This means the relay agent works correctly under normal conditions (using 192.168.0.1), but after the link flap, it switches to using the secondary IP 192.169.0.1.

When the relay agent relays a server response (Offer/ACK/NAK) back to the client, it should set the source IP to the giaddr from the incoming packet rather than arbitrarily picking an address from the VLAN interface. This ensures consistency regardless of how many IPs are on the interface or what order they're enumerated after a re-initialization.
fix:-
In prepare_vlan_sockets(), the code iterated through all IPs on the VLAN interface via getifaddrs() and blindly took the last matching IP without checking if it was a secondary address. When Vlan1000 has two IPs (192.168.0.1 primary and 192.169.0.1 secondary), the order returned by getifaddrs() can change after a link flap, causing the client socket to bind to the secondary IP 192.169.0.1.
This contrasts with prepare_relay_interface_config(), which correctly checks CONFIG_DB for the "secondary" flag and only selects primary IPs.