### PR TITLE
[dhcp4relay] Fix VLAN client socket to bind to primary IP instead of secondary

### DIFF
--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -373,10 +373,18 @@ int prepare_vlan_sockets(relay_config &config) {
                 if (ifa_tmp->ifa_addr && (ifa_tmp->ifa_addr->sa_family == AF_INET)) {
                     if (strcmp(ifa_tmp->ifa_name, config.vlan.c_str()) == 0) {
                         struct sockaddr_in *in = (struct sockaddr_in *)ifa_tmp->ifa_addr;
-                        bind_client_addr = true;
-                        client_addr = *in;
-                        client_addr.sin_family = AF_INET;
-                        client_addr.sin_port = htons(RELAY_PORT);
+                        char ip_str[INET_ADDRSTRLEN];
+                        inet_ntop(AF_INET, &(in->sin_addr), ip_str, INET_ADDRSTRLEN);
+                        std::string value;
+                        std::shared_ptr<swss::Table> vlan_intf_tbl = std::make_shared<swss::Table>(config_db.get(), CFG_VLAN_INTF_TABLE_NAME);
+                        vlan_intf_tbl->hget((config.vlan + "|" + ip_str), "secondary", value);
+                        if ((value.size() == 0) || (value != "true")) {
+                            bind_client_addr = true;
+                            client_addr = *in;
+                            client_addr.sin_family = AF_INET;
+                            client_addr.sin_port = htons(RELAY_PORT);
+                            break;
+                        }
                     }
                 }
                 ifa_tmp = ifa_tmp->ifa_next;


### PR DESCRIPTION

In prepare_vlan_sockets(), the code iterated through all IPv4 addresses on the VLAN interface via getifaddrs() and unconditionally used the last matching IP for the client socket. When a VLAN has both a primary and a secondary IP (e.g. Vlan1000 with 192.168.0.1/21 primary and 192.169.0.1/22 secondary), the enumeration order from getifaddrs() can change after a link flap, causing the relay to bind to the secondary IP.

This resulted in DHCP Offer/ACK packets being relayed back to clients with the secondary IP as the source address instead of the expected primary IP (which matches the giaddr), breaking relay test validations and potentially confusing DHCP clients.

The fix queries CONFIG_DB (CFG_VLAN_INTF_TABLE_NAME) for each candidate IP to check the "secondary" flag, matching the approach already used in prepare_relay_interface_config(). Only non-secondary (primary) IPs are selected for binding, and the loop breaks immediately once a primary IP is found.