### PR TITLE
Backport master PR#87 and PR#88 together to 202511

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -33,9 +33,9 @@ jobs:
       set -ex
       sudo apt-get update
       sudo apt-get install -y \
-          libboost-system-dev \
-          libboost-thread-dev \
-          libboost-serialization-dev \
+          libboost-system1.83-dev \
+          libboost-thread1.83-dev \
+          libboost-serialization1.83-dev \
           googletest \
           libgtest-dev \
           libgmock-dev \

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,8 +40,8 @@ jobs:
       - name: prepare
         run: |
           sudo apt-get update
-          sudo apt-get install -y libboost-system-dev \
-            libboost-thread-dev \
+          sudo apt-get install -y libboost-system1.83-dev \
+            libboost-thread1.83-dev \
             libevent-dev \
             libhiredis-dev \
             libnl-3-dev \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,13 @@ trigger:
     include:
       - "*"
 
+variables:
+  - name: BUILD_BRANCH
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      value: $(System.PullRequest.TargetBranch)
+    ${{ else }}:
+      value: $(Build.SourceBranchName)
+
 jobs:
 - template: .azure-pipelines/build.yml
   parameters:
@@ -15,15 +22,14 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     codeCoverage: true
-    containerImage: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:latest
+    containerImage: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)
 - template: .azure-pipelines/build.yml
   parameters:
     arch: arm64
     pool: sonicso1ES-arm64
-    containerImage: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm-arm64:latest
+    containerImage: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)-arm64
 - template: .azure-pipelines/build.yml
   parameters:
     arch: armhf
     pool: sonicso1ES-armhf
-    containerImage: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm-armhf:latest
-
+    containerImage: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)-armhf

--- a/dhcp4relay/Makefile
+++ b/dhcp4relay/Makefile
@@ -23,7 +23,7 @@ PCAPPP_DONE = $(WORKING_DIR)/pcappp.stamp
 INCLUDE_DIR = $(PCAPPLUSPLUS_DIR)/include
 LIB_DIR = $(PCAPPLUSPLUS_DIR)/lib
 
-override LDLIBS += -levent -lhiredis -lswsscommon -pthread -lboost_thread -lboost_system $(LD_PCAPPLUSPLUS_LIB) -lpcap
+override LDLIBS += -levent -lhiredis -lswsscommon -pthread -lboost_thread $(LD_PCAPPLUSPLUS_LIB) -lpcap
 override CPPFLAGS += -Wall -std=c++17 -fPIE -I/usr/include/swss -I$(INCLUDE_DIR)
 override CPPFLAGS += -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)"
 override LDFLAGS += -L$(LIB_DIR) -Wl,-rpath=$(abspath $(LIB_DIR))

--- a/dhcp4relay/debian/control
+++ b/dhcp4relay/debian/control
@@ -2,7 +2,7 @@ Source: sonic-dhcp4relay
 Section: devel
 Priority: optional
 Maintainer: Ashutosh Agrawal <ashu@cisco.com>
-Build-Depends: debhelper (>= 12.0.0), libevent-dev, libboost-thread-dev, libboost-system-dev, libswsscommon-dev
+Build-Depends: debhelper (>= 12.0.0), libevent-dev, libboost-thread-dev | libboost-thread1.83-dev, libswsscommon-dev
 Standards-Version: 3.9.3
 Homepage: https://github.com/Azure/sonic-buildimage
 XS-Go-Import-Path: github.com/Azure/sonic-buildimage


### PR DESCRIPTION
Backport https://github.com/sonic-net/sonic-dhcp-relay/pull/87 to 202511
Backport https://github.com/sonic-net/sonic-dhcp-relay/pull/88 to 202511

These two PRs need to be ported together to get the CI to pass.

Without these changes, dhcp4relay build is failing on the following PR - https://github.com/sonic-net/sonic-buildimage/pull/25371