### PR TITLE
Fix secondary IP detection in VLAN interface lookup

### DIFF
--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -206,6 +206,38 @@ void prepare_relay_server_config(relay_config &interface_config) {
 }
 
 /**
+ * @code                        addr_is_primary(const std::string &ifname, const struct in_addr *addr);
+ *
+ * @brief                       Check if the given IPv4 address is primary on the interface
+ *                              by querying ConfigDB. Searches for matching VLAN_INTERFACE
+ *                              keys and checks the "secondary" field.
+ *
+ * @param ifname                interface name (e.g. "Vlan1000")
+ * @param addr                  pointer to the IPv4 address to check
+ *
+ * @return                      true if the address is primary or not found in ConfigDB, false if secondary
+ */
+bool addr_is_primary(const std::string &ifname, const struct in_addr *addr) {
+    auto match_pattern = std::string("*") + CFG_VLAN_INTF_TABLE_NAME + "|" + ifname + "|*";
+    auto keys = config_db->keys(match_pattern);
+
+    for (const auto &key : keys) {
+        auto last_bar = key.find_last_of('|');
+        auto last_slash = key.find_last_of('/');
+        if (last_bar == std::string::npos || last_slash == std::string::npos || last_bar >= last_slash) {
+            continue;
+        }
+        auto addr_str = key.substr(last_bar + 1, last_slash - last_bar - 1);
+        struct in_addr curr_addr;
+        if (inet_pton(AF_INET, addr_str.c_str(), &curr_addr) == 1 && curr_addr.s_addr == addr->s_addr) {
+            auto val = config_db->hget(key, "secondary");
+            return val == nullptr || *val != "true";
+        }
+    }
+    return true;
+}
+
+/**
  * @code                        prepare_relay_interface_config(relay_config &interface_config);
  *
  * @brief                       prepare for specified relay interface config: server and link address
@@ -253,12 +285,7 @@ void prepare_relay_interface_config(relay_config &interface_config) {
             struct sockaddr_in *in = (struct sockaddr_in *)ifa_tmp->ifa_addr;
             struct sockaddr_in *mask = (struct sockaddr_in *)ifa_tmp->ifa_netmask;
             if (strcmp(ifa_tmp->ifa_name, interface_config.vlan.c_str()) == 0) {
-                char ip_str[INET_ADDRSTRLEN];
-                inet_ntop(AF_INET, &(in->sin_addr), ip_str, INET_ADDRSTRLEN);
-                std::string value;
-                std::shared_ptr<swss::Table> vlan_intf_tbl = std::make_shared<swss::Table>(config_db.get(), CFG_VLAN_INTF_TABLE_NAME);
-                vlan_intf_tbl->hget((interface_config.vlan + "|" + ip_str), "secondary", value);
-                if ((value.size() == 0) || (value != "true")) {
+                if (addr_is_primary(interface_config.vlan, &in->sin_addr)) {
                     intf_addr = *in;
                     net_mask = *mask;
                     intf_name_set = true;

--- a/dhcp4relay/src/dhcp4relay.h
+++ b/dhcp4relay/src/dhcp4relay.h
@@ -178,6 +178,18 @@ struct metadata_config {
 int sock_open(const struct sock_fprog *fprog);
 
 /**
+ * @code                        addr_is_primary(const std::string &ifname, const struct in_addr *addr);
+ *
+ * @brief                       Check if the given IPv4 address is primary on the interface
+ *
+ * @param ifname                interface name (e.g. "Vlan1000")
+ * @param addr                  pointer to the IPv4 address to check
+ *
+ * @return                      true if the address is primary or not found in ConfigDB, false if secondary
+ */
+bool addr_is_primary(const std::string &ifname, const struct in_addr *addr);
+
+/**
  * @code                prepare_vlan_sockets(relay_config &config);
  *
  * @brief               prepare vlan L3 socket for sending
@@ -194,27 +206,6 @@ int prepare_vlan_sockets(relay_config &config);
  * @return              int
  */
 int prepare_vrf_sockets(relay_config &config);
-
-/**
- * @code                        prepare_relay_interface_config(relay_config &interface_config);
- *
- * @brief                       prepare for specified relay interface config
- *
- * @param interface_config      pointer to relay config to be prepared
- *
- * @return                      none
- */
-/**
- * @code                        addr_is_primary(const std::string &ifname, const struct in_addr *addr);
- *
- * @brief                       Check if the given IPv4 address is primary on the interface
- *
- * @param ifname                interface name (e.g. "Vlan1000")
- * @param addr                  pointer to the IPv4 address to check
- *
- * @return                      true if the address is primary or not found in ConfigDB, false if secondary
- */
-bool addr_is_primary(const std::string &ifname, const struct in_addr *addr);
 
 /**
  * @code                        prepare_relay_interface_config(relay_config &interface_config);

--- a/dhcp4relay/src/dhcp4relay.h
+++ b/dhcp4relay/src/dhcp4relay.h
@@ -204,6 +204,27 @@ int prepare_vrf_sockets(relay_config &config);
  *
  * @return                      none
  */
+/**
+ * @code                        addr_is_primary(const std::string &ifname, const struct in_addr *addr);
+ *
+ * @brief                       Check if the given IPv4 address is primary on the interface
+ *
+ * @param ifname                interface name (e.g. "Vlan1000")
+ * @param addr                  pointer to the IPv4 address to check
+ *
+ * @return                      true if the address is primary or not found in ConfigDB, false if secondary
+ */
+bool addr_is_primary(const std::string &ifname, const struct in_addr *addr);
+
+/**
+ * @code                        prepare_relay_interface_config(relay_config &interface_config);
+ *
+ * @brief                       prepare for specified relay interface config: server and link address
+ *
+ * @param interface_config      pointer to relay config to be prepared
+ *
+ * @return                      none
+ */
 void prepare_relay_interface_config(relay_config &interface_config);
 
 /**

--- a/dhcp4relay/test/mock_relay.cpp
+++ b/dhcp4relay/test/mock_relay.cpp
@@ -9,6 +9,7 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "mock_relay.h"
+#include "mock_table.h"
 #include <sys/syscall.h>
 
 #include <pcapplusplus/DhcpLayer.h>
@@ -78,6 +79,7 @@ void FreeMockIfaddrs(struct ifaddrs *mock_ifaddrs) {
         delete mock_ifaddrs;
     }
 }
+
 
 TEST(EncodeDecodeTLV, EncodeAndDecode) {
     uint8_t buffer[10] = {};
@@ -150,6 +152,40 @@ TEST(prepareConfig, prepare_relay_interface_config) {
     EXPECT_EQ(interface_config.src_intf_sel_addr.sin_addr.s_addr, inet_addr("192.168.1.2"));
 
     FreeMockIfaddrs(mock_ifaddrs);
+}
+
+
+TEST(addrIsPrimary, primary_ip_returns_true) {
+    swss::Table vlan_intf_table(config_db.get(), "VLAN_INTERFACE");
+    std::vector<std::pair<std::string, std::string>> empty_values = {{"NULL", "NULL"}};
+    vlan_intf_table.set("Vlan1000|192.168.0.1/21", empty_values);
+
+    struct in_addr addr;
+    inet_pton(AF_INET, "192.168.0.1", &addr);
+    EXPECT_TRUE(addr_is_primary("Vlan1000", &addr));
+
+    testing_db::reset();
+}
+
+TEST(addrIsPrimary, secondary_ip_returns_false) {
+    swss::Table vlan_intf_table(config_db.get(), "VLAN_INTERFACE");
+    std::vector<std::pair<std::string, std::string>> secondary_values = {{"secondary", "true"}};
+    vlan_intf_table.set("Vlan1000|192.169.0.1/22", secondary_values);
+
+    struct in_addr addr;
+    inet_pton(AF_INET, "192.169.0.1", &addr);
+    EXPECT_FALSE(addr_is_primary("Vlan1000", &addr));
+
+    testing_db::reset();
+}
+
+TEST(addrIsPrimary, unknown_ip_returns_true) {
+    // An IP not in CONFIG_DB should be treated as primary
+    struct in_addr addr;
+    inet_pton(AF_INET, "10.10.10.10", &addr);
+    EXPECT_TRUE(addr_is_primary("Vlan1000", &addr));
+
+    testing_db::reset();
 }
 
 TEST(prepareConfig, prepare_vlan_sockets) {

--- a/dhcp4relay/test/mock_table.cpp
+++ b/dhcp4relay/test/mock_table.cpp
@@ -150,11 +150,40 @@ namespace swss
             std::shared_ptr<std::string> ptr(new std::string(value));
             return ptr;
         }
-        else
+        // Also try Table-style storage: split key at first "|" into tableName and subKey
+        auto first_bar = key.find('|');
+        if (first_bar != std::string::npos)
         {
-            return std::shared_ptr<std::string>(NULL);
+            std::string tableName = key.substr(0, first_bar);
+            std::string subKey = key.substr(first_bar + 1);
+            if (_hget(getDbId(), tableName, subKey, field, value))
+            {
+                std::shared_ptr<std::string> ptr(new std::string(value));
+                return ptr;
+            }
         }
+        return nullptr;
     }
+    std::vector<std::string> DBConnector::keys(const std::string &pattern)
+    {
+        std::vector<std::string> matched_keys;
+        auto star1 = pattern.find('*');
+        auto star2 = pattern.rfind('*');
+        if (star1 == 0 && star2 == pattern.size() - 1 && star1 != star2) {
+            // Pattern: *middle*
+            std::string middle = pattern.substr(1, pattern.size() - 2);
+            for (const auto &table : gDB[getDbId()]) {
+                for (const auto &entry : table.second) {
+                    std::string full_key = table.first + "|" + entry.first;
+                    if (full_key.find(middle) != std::string::npos) {
+                        matched_keys.push_back(full_key);
+                    }
+                }
+            }
+        }
+        return matched_keys;
+    }
+
 
     void ProducerTable::set(const std::string &key,
                             const std::vector<FieldValueTuple> &values,


### PR DESCRIPTION
The relay was using IP address without prefix length (e.g. 192.169.0.1) to look up the VLAN_INTERFACE table in CONFIG_DB, but the actual keys include the prefix length (e.g. 192.169.0.1/22). This caused the secondary flag lookup to always fail, making the relay pick the last IP found on the interface instead of the primary one.

On topologies with multiple IPs on Vlan (e.g. t0-116 with both 192.168.0.1/21 and 192.169.0.1/22), the relay would use the secondary IP as giaddr/source, causing DHCP relay failures.

Fix: compute prefix length from netmask and include it in the CONFIG_DB lookup key, matching the key format used by CONFIG_DB (VLAN_INTERFACE|Vlan1000|192.169.0.1/22).