### PR TITLE
Fix to_client using wrong source IP on multi-IP VLAN interfaces

### DIFF
--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -754,7 +754,6 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
     target_addr.sin_family = AF_INET;
     target_addr.sin_port = htons(CLIENT_PORT);
 
-    in_addr ip_zero = {0};
     /* TODO: Send unicast message to client if BOOTP flag from client is set to unicast */
 
     /* Perform padding only when DHCP relay (Option 82) information has been stripped from the packet */
@@ -763,7 +762,8 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
         pad = true;
     }
 
-    if (send_udp(config.client_sock, (uint8_t *)dhcp_pkt->getDhcpHeader(), target_addr, dhcp_pkt->getHeaderLen(), ip_zero, false, pad)) {
+    /* Use the primary VLAN IP as source address to avoid picking a secondary IP */
+    if (send_udp(config.client_sock, (uint8_t *)dhcp_pkt->getDhcpHeader(), target_addr, dhcp_pkt->getHeaderLen(), config.link_address.sin_addr, true, pad)) {
         syslog(LOG_INFO, "[DHCPV4_RELAY] dhcp relay message is broadcast to client %s from server %s",
                config.vlan.c_str(), src_ip.c_str());
         dhcp_cntr_table.increment_counter(config.vlan, "TX", (int)dhcp_pkt->getMessageType());


### PR DESCRIPTION
In to_client(), the relay sends the DHCP response to the client using ip_zero (0.0.0.0) as the source address, letting the kernel select the source IP. On VLAN interfaces with multiple IPs (e.g. primary 192.168.0.1/21 and secondary 192.169.0.1/22), the kernel may pick the secondary IP, causing the client to receive the response with an unexpected source address.

Fix: use config.link_address (the primary VLAN IP, already resolved during relay initialization) as the explicit source IP in send_udp(), instead of relying on kernel source IP selection.