### PR TITLE
Fix VLAN socket binding to secondary IP on multi-IP interfaces

### DIFF
--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -400,10 +400,13 @@ int prepare_vlan_sockets(relay_config &config) {
                 if (ifa_tmp->ifa_addr && (ifa_tmp->ifa_addr->sa_family == AF_INET)) {
                     if (strcmp(ifa_tmp->ifa_name, config.vlan.c_str()) == 0) {
                         struct sockaddr_in *in = (struct sockaddr_in *)ifa_tmp->ifa_addr;
-                        bind_client_addr = true;
-                        client_addr = *in;
-                        client_addr.sin_family = AF_INET;
-                        client_addr.sin_port = htons(RELAY_PORT);
+                        if (addr_is_primary(config.vlan, &in->sin_addr)) {
+                            bind_client_addr = true;
+                            client_addr = *in;
+                            client_addr.sin_family = AF_INET;
+                            client_addr.sin_port = htons(RELAY_PORT);
+                            break;
+                        }
                     }
                 }
                 ifa_tmp = ifa_tmp->ifa_next;


### PR DESCRIPTION
Problem

On VLAN interfaces with multiple IP addresses (e.g., t0-116 topology with 192.168.0.1/21 primary and 192.169.0.1/22 secondary on Vlan1000), the DHCP relay binds its client-facing socket to the secondary IP. This causes all DHCP responses relayed to clients (offers, ACKs) to have the wrong source IP address, breaking relay functionality.

Root Cause

In prepare_vlan_sockets(), the code iterates getifaddrs() and overwrites client_addr with each IPv4 address found on the VLAN interface without checking the secondary flag in CONFIG_DB. The socket ends up bound to the last IP found (the secondary), and all subsequent sendto() calls use that address as the source.

Fix

Use addr_is_primary() (introduced in PR #97) to skip secondary IPs when selecting the address for socket binding. Break on the first primary IP found.

Dependencies

This PR depends on PR #97 (fix/secondary-ip-lookup) which introduces the addr_is_primary() helper function. After #97 merges, this branch will be rebased to master.

Testing

 - Verified on hardware testbed (Arista 7260, t0-116 topology) that the relay socket was binding to 192.169.0.1 (secondary) instead of 192.168.0.1 (primary)
 - Confirmed via tcpdump that DHCP offer responses used the wrong source IP (192.169.0.1)
 - With this fix, the socket binds to the primary IP and responses use 192.168.0.1
