### PR TITLE
[dhcp4relay] Fix agent_relay_mode: add forward mode, align with ISC behavior

### DIFF
--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -591,17 +591,20 @@ void from_client(pcpp::DhcpLayer *dhcp_pkt, relay_config &config) {
     } else {
         /* If the relay packet is from another relay, we should act based on
            configuration of agent_relay_mode.
-           append - Forward the packet with appending relay agent.
-           replace - Delete existing option 82 and add my relay option.
-           discard - Discard the incoming packet.
+           append  - Forward the packet with appending our own relay option.
+           replace - Delete existing option 82 and add our relay option.
+           forward - Forward the packet unchanged (no Option 82 modification).
+           discard - Discard the incoming packet (default).
          */
         if (config.agent_relay_mode == "append") {
             encode_relay_option(dhcp_pkt, &config);
         } else if (config.agent_relay_mode == "replace") {
             dhcp_pkt->removeOption(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS);
             encode_relay_option(dhcp_pkt, &config);
+        } else if (config.agent_relay_mode == "forward") {
+            /* forward_untouched: pass through without modifying Option 82 */
         } else {
-            /* By default it will discard packet from relay agent */
+            /* discard: explicit "discard" value or any unrecognized value */
             dhcp_cntr_table.increment_counter(config.vlan, "TX", DHCPv4_MESSAGE_TYPE_DROP);
             syslog(LOG_INFO, "[DHCPV4_RELAY] agent relay mode is discard, dropping the packet %s",
                    config.vlan.c_str());

--- a/dhcp4relay/test/mock_relay.cpp
+++ b/dhcp4relay/test/mock_relay.cpp
@@ -937,3 +937,100 @@ TEST(DHCPRelayTest, from_client) {
     });
     from_client(&dhcpLayer, config);
 }
+
+/* Helper: build a relay-of-relay packet (giaddr already set) with a pre-existing Option 82. */
+static relay_config make_relay_of_relay_config(const std::string &agent_relay_mode) {
+    interface_list.push_back("Ethernet12");
+    phy_interface_alias_map["Ethernet12"] = "eth12";
+
+    relay_config config = {};
+    config.phy_interface = "Ethernet12";
+    config.vlan = "Vlan10";
+    config.agent_relay_mode = agent_relay_mode;
+    config.max_hop_count = 16;
+    struct sockaddr_in addr = {0};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = inet_addr("192.168.20.100");
+    config.servers_sock = {addr};
+    config.servers = {"192.168.20.100"};
+    config.link_address.sin_addr.s_addr = inet_addr("192.168.10.10");
+    config.link_address_netmask.sin_addr.s_addr = inet_addr("255.255.255.0");
+    vlan_vrf_map["Vlan10"] = "Vrf01";
+    m_config.host_mac_addr = "12:32:54:24:95:36";
+    return config;
+}
+
+/* agent_relay_mode=append: packet already has Option 82; we should append ours and forward. */
+TEST(DHCPRelayTest, from_client_relay_of_relay_append) {
+    relay_config config = make_relay_of_relay_config("append");
+
+    pcpp::MacAddress clientMac(std::string("00:0e:86:11:c0:75"));
+    pcpp::DhcpLayer dhcpLayer(pcpp::DHCP_DISCOVER, clientMac);
+    dhcpLayer.getDhcpHeader()->hops = 0;
+    /* Non-zero giaddr signals relay-of-relay path */
+    dhcpLayer.getDhcpHeader()->gatewayIpAddress = inet_addr("192.168.1.1");
+    encode_relay_option(&dhcpLayer, &config);
+
+    EXPECT_GLOBAL_CALL(send_udp, send_udp(_, _, _, _, _, _, _)).WillOnce([]
+            (int, uint8_t* hdr, struct sockaddr_in, uint32_t, in_addr, bool, bool) {
+        pcpp::dhcp_header* dhcp_hdr = (pcpp::dhcp_header*)hdr;
+        EXPECT_EQ(dhcp_hdr->hops, 1);
+        EXPECT_EQ(dhcp_hdr->gatewayIpAddress, inet_addr("192.168.1.1"));
+        return true;
+    });
+    from_client(&dhcpLayer, config);
+}
+
+/* agent_relay_mode=replace: existing Option 82 stripped, ours added, packet forwarded. */
+TEST(DHCPRelayTest, from_client_relay_of_relay_replace) {
+    relay_config config = make_relay_of_relay_config("replace");
+
+    pcpp::MacAddress clientMac(std::string("00:0e:86:11:c0:75"));
+    pcpp::DhcpLayer dhcpLayer(pcpp::DHCP_DISCOVER, clientMac);
+    dhcpLayer.getDhcpHeader()->hops = 0;
+    dhcpLayer.getDhcpHeader()->gatewayIpAddress = inet_addr("192.168.1.1");
+    encode_relay_option(&dhcpLayer, &config);
+
+    EXPECT_GLOBAL_CALL(send_udp, send_udp(_, _, _, _, _, _, _)).WillOnce([]
+            (int, uint8_t* hdr, struct sockaddr_in, uint32_t, in_addr, bool, bool) {
+        pcpp::dhcp_header* dhcp_hdr = (pcpp::dhcp_header*)hdr;
+        EXPECT_EQ(dhcp_hdr->hops, 1);
+        EXPECT_EQ(dhcp_hdr->gatewayIpAddress, inet_addr("192.168.1.1"));
+        return true;
+    });
+    from_client(&dhcpLayer, config);
+}
+
+/* agent_relay_mode=forward: packet forwarded unchanged, Option 82 not modified. */
+TEST(DHCPRelayTest, from_client_relay_of_relay_forward) {
+    relay_config config = make_relay_of_relay_config("forward");
+
+    pcpp::MacAddress clientMac(std::string("00:0e:86:11:c0:75"));
+    pcpp::DhcpLayer dhcpLayer(pcpp::DHCP_DISCOVER, clientMac);
+    dhcpLayer.getDhcpHeader()->hops = 0;
+    dhcpLayer.getDhcpHeader()->gatewayIpAddress = inet_addr("192.168.1.1");
+    encode_relay_option(&dhcpLayer, &config);
+
+    EXPECT_GLOBAL_CALL(send_udp, send_udp(_, _, _, _, _, _, _)).WillOnce([]
+            (int, uint8_t* hdr, struct sockaddr_in, uint32_t, in_addr, bool, bool) {
+        pcpp::dhcp_header* dhcp_hdr = (pcpp::dhcp_header*)hdr;
+        EXPECT_EQ(dhcp_hdr->hops, 1);
+        EXPECT_EQ(dhcp_hdr->gatewayIpAddress, inet_addr("192.168.1.1"));
+        return true;
+    });
+    from_client(&dhcpLayer, config);
+}
+
+/* agent_relay_mode=discard: packet must be dropped, send_udp must NOT be called. */
+TEST(DHCPRelayTest, from_client_relay_of_relay_discard) {
+    relay_config config = make_relay_of_relay_config("discard");
+
+    pcpp::MacAddress clientMac(std::string("00:0e:86:11:c0:75"));
+    pcpp::DhcpLayer dhcpLayer(pcpp::DHCP_DISCOVER, clientMac);
+    dhcpLayer.getDhcpHeader()->hops = 0;
+    dhcpLayer.getDhcpHeader()->gatewayIpAddress = inet_addr("192.168.1.1");
+    encode_relay_option(&dhcpLayer, &config);
+
+    EXPECT_GLOBAL_CALL(send_udp, send_udp(_, _, _, _, _, _, _)).Times(0);
+    from_client(&dhcpLayer, config);
+}


### PR DESCRIPTION
#### Why I did it

The daemon only handled `append` and `replace` explicitly in `from_client()`.
All other values — including `forward_untouched` (the YANG default), `discard`,
and any unrecognized string — fell to an else-branch that silently dropped the
packet. This meant:

- `forward_untouched` dropped packets instead of forwarding them unchanged,
  despite the YANG default being set to that value.
- `discard` worked only by accident via the else fallthrough.
- There was no way to configure pass-through (forward untouched) behavior,
  unlike ISC dhcrelay which supports `-m forward`.

This is the daemon-side fix for sonic-net/sonic-mgmt#24052.

#### How I did it

Add `forward` as an explicit mode in `from_client()` that passes relay-of-relay
packets through without modifying Option 82. Make `discard` explicit in the
else branch. Update the comment to document all four modes: `append`, `replace`,
`forward`, `discard`.

Also add unit tests for all four relay-of-relay modes. Previously none of
the `agent_relay_mode` code paths in `from_client()` had test coverage.

#### How to verify it

```
cd dhcp4relay && make test
```

New tests added:
- `from_client_relay_of_relay_append`  — `send_udp` called, option appended
- `from_client_relay_of_relay_replace` — `send_udp` called, option replaced
- `from_client_relay_of_relay_forward` — `send_udp` called, packet unchanged
- `from_client_relay_of_relay_discard` — `send_udp` NOT called