### PR TITLE
[dhcp4relay] Upstream quality, memory, and Option-82 fixes

### DIFF
--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -825,6 +825,29 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
 }
 
 /**
+ * @code                update_interface_vlan_mapping(std::string interface, std::string vlan, bool is_add);
+ *
+ * @brief               update interface to vlan mapping and DHCP counter table
+ *
+ * @param interface     interface name string
+ * @param vlan          vlan name string
+ * @param is_add        add or delete entry
+ *
+ * @return              none
+ */
+void update_interface_vlan_mapping(std::string interface, std::string vlan, bool is_add) {
+    if (is_add) {
+        vlan_map[interface] = vlan;
+        dhcp_cntr_table.initialize_interface(vlan);
+        syslog(LOG_INFO, "[DHCPV4_RELAY] Add <%s, %s> into interface vlan map\n", interface.c_str(), vlan.c_str());
+    } else {
+        vlan_map.erase(interface);
+        dhcp_cntr_table.remove_interface(vlan);
+        syslog(LOG_INFO, "[DHCPV4_RELAY] Remove <%s, %s> from interface vlan map\n", interface.c_str(), vlan.c_str());
+    }
+}
+
+/**
  * @code                update_vlan_mapping(std::string vlan, bool is_add);
  *
  * @brief               build vlan member interface to vlan mapping table
@@ -855,15 +878,7 @@ void update_vlan_mapping(std::string vlan, bool is_add) {
     for (auto &itr : keys) {
         auto found = itr.find_last_of('|');
         auto interface = itr.substr(found + 1);
-        if (is_add) {
-            vlan_map[interface] = vlan;
-            dhcp_cntr_table.initialize_interface(vlan);
-            syslog(LOG_INFO, "[DHCPV4_RELAY] Add <%s, %s> into interface vlan map\n", interface.c_str(), vlan.c_str());
-        } else {
-            vlan_map.erase(interface);
-            dhcp_cntr_table.remove_interface(vlan);
-            syslog(LOG_INFO, "[DHCPV4_RELAY] Remove <%s, %s> from interface vlan map\n", interface.c_str(), vlan.c_str());
-        }
+        update_interface_vlan_mapping(interface, vlan, is_add);
     }
 
     /* get VRF attached to the vlan from VLAN_INTERFACE table */
@@ -1334,15 +1349,7 @@ void config_event_callback(evutil_socket_t fd, short event, void *arg) {
                        (*vlans)[msg->vlan].client_sock = 0;
                    }
 
-                   if (msg->is_add) {
-                       vlan_map[msg->interface] = msg->vlan;
-                       dhcp_cntr_table.initialize_interface(msg->vlan);
-                       syslog(LOG_INFO, "[DHCPV4_RELAY] Add <%s, %s> into interface vlan map\n", msg->interface.c_str(), msg->vlan.c_str());
-                   } else {
-                       vlan_map.erase(msg->interface);
-                       dhcp_cntr_table.remove_interface(msg->vlan);
-                       syslog(LOG_INFO, "[DHCPV4_RELAY] Remove <%s, %s> from interface vlan map\n", msg->interface.c_str(), msg->vlan.c_str());
-                   }
+                   update_interface_vlan_mapping(msg->interface, msg->vlan, msg->is_add);
                    /* Do not early-return on socket failure: msg is freed
                       immediately below; no code follows between here and delete. */
                    if (prepare_vlan_sockets((*vlans)[msg->vlan]) == -1) {

--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -248,9 +248,9 @@ bool addr_is_primary(const std::string &ifname, const struct in_addr *addr) {
  */
 void prepare_relay_interface_config(relay_config &interface_config) {
     struct ifaddrs *ifa, *ifa_tmp;
-    sockaddr_in intf_addr;
-    sockaddr_in net_mask;
-    sockaddr_in src_intf_sel;
+    sockaddr_in intf_addr = {};
+    sockaddr_in net_mask = {};
+    sockaddr_in src_intf_sel = {};
     bool intf_name_set = false;
     bool source_intf_sel_opt = false;
 
@@ -290,8 +290,9 @@ void prepare_relay_interface_config(relay_config &interface_config) {
                     net_mask = *mask;
                     intf_name_set = true;
                 }
-            } else if ((!source_intf_sel_opt) &&
-                       (strcmp(ifa_tmp->ifa_name, interface_config.source_interface.c_str()) == 0)) {
+            }
+	    if ((!source_intf_sel_opt) &&
+                (strcmp(ifa_tmp->ifa_name, interface_config.source_interface.c_str()) == 0)) {
                 src_intf_sel = *in;
                 source_intf_sel_opt = true;
             }
@@ -339,30 +340,33 @@ int prepare_vrf_sockets(relay_config &config) {
         addr.sin_family = AF_INET;
         addr.sin_addr.s_addr = htonl(INADDR_ANY);
         addr.sin_port = htons(RELAY_PORT);
-        bind(vrf_sock, (struct sockaddr*)&addr, sizeof(addr));
+        if (bind(vrf_sock, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
+            syslog(LOG_ERR, "[DHCPV4_RELAY] bind: Failed to bind vrf socket for %s, error: %s\n",
+                   config.vrf.c_str(), strerror(errno));
+            close(vrf_sock);
+            return -1;
+        }
 
         /* Update the map */
         vrf_sock_map[config.vrf] = {vrf_sock, 1};
-    }
-
-    if (vrf_sock > 0) {
         config.vrf_sock = vrf_sock;
     } else {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to obtain vrf socket(%s) error:%s \n", config.vrf.c_str(), strerror(errno));
-        return -1;
+        config.vrf_sock = itr->second.sock;
+        itr->second.ref_count++;
     }
     return 0;
 }
 
 /**
- * @code                prepare_vlan_sockets(int &client_sock, relay_config &config);
+ * @code                prepare_vlan_sockets(relay_config &config);
  *
- * @brief               prepare vlan L3 socket for sending
+ * @brief               prepare vlan L3 socket for sending replies to clients.
+ *                      Returns -1 if no IPv4 address is assigned yet (deferred creation);
+ *                      the socket will be created when a VLAN_INTERFACE_UPDATE event arrives.
  *
- * @param client_sock      socket binded to ip address of vlan interface on which server is configured.
- *                      This socket will be used to send DHCP packet to server and client.
+ * @param config        relay config whose client_sock will be set on success
  *
- * @return              int
+ * @return              0 on success, -1 on failure or deferred
  */
 int prepare_vlan_sockets(relay_config &config) {
 #ifdef UNIT_TEST
@@ -370,6 +374,36 @@ int prepare_vlan_sockets(relay_config &config) {
 #else
     struct ifaddrs *ifa, *ifa_tmp;
     sockaddr_in client_addr = {0};
+    bool bind_client_addr = false;
+
+    if (getifaddrs(&ifa) == -1) {
+        syslog(LOG_WARNING, "[DHCPV4_RELAY] getifaddrs: Unable to get network interfaces with %s\n", strerror(errno));
+        return -1;
+    }
+
+    ifa_tmp = ifa;
+    while (ifa_tmp) {
+        if (ifa_tmp->ifa_addr && (ifa_tmp->ifa_addr->sa_family == AF_INET)) {
+            if (strcmp(ifa_tmp->ifa_name, config.vlan.c_str()) == 0) {
+                struct sockaddr_in *in = (struct sockaddr_in *)ifa_tmp->ifa_addr;
+                if (addr_is_primary(config.vlan, &in->sin_addr)) {
+                    bind_client_addr = true;
+                    client_addr = *in;
+                    client_addr.sin_family = AF_INET;
+                    client_addr.sin_port = htons(RELAY_PORT);
+                    break;
+                }
+            }
+        }
+        ifa_tmp = ifa_tmp->ifa_next;
+    }
+    freeifaddrs(ifa);
+
+    if (!bind_client_addr) {
+        syslog(LOG_NOTICE, "[DHCPV4_RELAY] No IPv4 address on interface %s, deferring socket creation\n", config.vlan.c_str());
+        return -1;
+    }
+
     int client_sock = 0;
     if ((client_sock = socket(AF_INET, SOCK_DGRAM, 0)) == -1) {
         syslog(LOG_ERR, "[DHCPV4_RELAY] socket: Failed to create client_addr socket on interface %s, error: %s\n",
@@ -389,43 +423,9 @@ int prepare_vlan_sockets(relay_config &config) {
         return -1;
     }
 
-    int retry = 0;
-    bool bind_client_addr = false;
-    do {
-        if (getifaddrs(&ifa) == -1) {
-            syslog(LOG_WARNING, "[DHCPV4_RELAY] getifaddrs: Unable to get network interfaces with %s\n", strerror(errno));
-        } else {
-            ifa_tmp = ifa;
-            while (ifa_tmp) {
-                if (ifa_tmp->ifa_addr && (ifa_tmp->ifa_addr->sa_family == AF_INET)) {
-                    if (strcmp(ifa_tmp->ifa_name, config.vlan.c_str()) == 0) {
-                        struct sockaddr_in *in = (struct sockaddr_in *)ifa_tmp->ifa_addr;
-                        if (addr_is_primary(config.vlan, &in->sin_addr)) {
-                            bind_client_addr = true;
-                            client_addr = *in;
-                            client_addr.sin_family = AF_INET;
-                            client_addr.sin_port = htons(RELAY_PORT);
-                            break;
-                        }
-                    }
-                }
-                ifa_tmp = ifa_tmp->ifa_next;
-            }
-            freeifaddrs(ifa);
-        }
-
-        if (bind_client_addr) {
-            break;
-        }
-
-        syslog(LOG_WARNING, "[DHCPV4_RELAY] Retry #%d to bind to sockets on interface %s\n", ++retry, config.vlan.c_str());
-        sleep(5);
-    } while (retry < 6);
-
-    if ((!bind_client_addr) || (bind(client_sock, (sockaddr *)&client_addr, sizeof(client_addr)) == -1)) {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] bind: Failed to bind socket to global ipv4 address on interface %s after %d retries with %s\n",
-               config.vlan.c_str(), retry, strerror(errno));
-        /* TODO: Need to close vrf socket if ref count is zero in all failure case */
+    if (bind(client_sock, (sockaddr *)&client_addr, sizeof(client_addr)) == -1) {
+        syslog(LOG_ERR, "[DHCPV4_RELAY] bind: Failed to bind socket to IPv4 address on interface %s: %s\n",
+               config.vlan.c_str(), strerror(errno));
         close(client_sock);
         return -1;
     }
@@ -583,6 +583,13 @@ void from_client(pcpp::DhcpLayer *dhcp_pkt, relay_config &config) {
             dhcp_pkt->getDhcpHeader()->gatewayIpAddress =
                 config.link_address.sin_addr.s_addr;
         }
+        if (!(dhcp_pkt->getDhcpHeader()->gatewayIpAddress)) {
+            syslog(LOG_ERR, "[DHCPV4_RELAY] No IPv4 address configured on %s,\n"
+                   " dropping DHCP packet. Configure an IPv4 address on the VLAN"
+                   " interface for relay to function", config.vlan.c_str());
+            dhcp_cntr_table.increment_counter(config.vlan, "TX", DHCPv4_MESSAGE_TYPE_DROP);
+            return;
+        }
         if ((dhcp_pkt->getDhcpHeader()->magicNumber) &&
             (dhcp_pkt->getDhcpHeader()->magicNumber) == DHCP_MAGIC_NUMBER) {
             syslog(LOG_WARNING, "[DHCPV4_RELAY] encode DHCP relay option");
@@ -635,13 +642,14 @@ void from_client(pcpp::DhcpLayer *dhcp_pkt, relay_config &config) {
     }
 
     for (auto server : config.servers_sock) {
+        const char *server_str = (index < config.servers.size()) ? config.servers[index].c_str() : "<unknown>";
         if (send_udp(sock, (uint8_t *)dhcp_pkt->getDhcpHeader(), server, dhcp_pkt->getHeaderLen(), src_ip, use_intf_ip_as_src_ip, true)) {
             syslog(LOG_INFO, "[DHCPV4_RELAY] DHCP packet is sent to configured server: %s, interface: %s",
-                   config.servers[index].c_str(), config.vlan.c_str());
+                   server_str, config.vlan.c_str());
             dhcp_cntr_table.increment_counter(config.vlan, "TX", (int)dhcp_pkt->getMessageType());
         } else {
             syslog(LOG_NOTICE, "[DHCPV4_RELAY] DHCP packet sending FAILED for configured server: %s, interface: %s",
-                   config.servers[index].c_str(), config.vlan.c_str());
+                   server_str, config.vlan.c_str());
             // increment drop counter
             dhcp_cntr_table.increment_counter(config.vlan, "TX", DHCPv4_MESSAGE_TYPE_DROP);
         }
@@ -698,13 +706,14 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
 
     if (getifaddrs(&ifa) == -1) {
         syslog(LOG_WARNING, "[DHCPV4_RELAY] getifaddrs: Unable to get network interfaces, error: %s\n", strerror(errno));
-        exit(1);
+        return;
     }
 
     /* Return if giaddr is empty */
     if (giaddr == 0) {
         syslog(LOG_ERR, "[DHCPV4_RELAY] Message received with empty giaddr from server %s\n",
                src_ip.c_str());
+        freeifaddrs(ifa);
         return;
     }
 
@@ -720,8 +729,9 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
         if (circuit_id_ptr == NULL) {
             syslog(LOG_ERR,
                     "[DHCPV4_RELAY] Circuit id sub-option is missing in relay"
-                    " agent option from server %s",
+                    " agent option from server %s\n",
                     src_ip.c_str());
+            freeifaddrs(ifa);
             return;
         }
 
@@ -773,6 +783,7 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
         config_itr = vlans->find(intf_name);
         if (config_itr == vlans->end()) {
             syslog(LOG_ERR, "[DHCPV4_RELAY] Config not found for vlan %s\n", intf_name.c_str());
+            dhcp_cntr_table.increment_counter(intf_name, "RX", DHCPv4_MESSAGE_TYPE_DROP);
             return;
         }
     } else {
@@ -790,6 +801,13 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
     in_addr ip_zero = {0};
     /* TODO: Send unicast message to client if BOOTP flag from client is set to unicast */
 
+    if (config.client_sock <= 0) {
+        syslog(LOG_WARNING, "[DHCPV4_RELAY] Dropping server reply for %s: VLAN socket not ready (no IPv4 address)\n",
+               config.vlan.c_str());
+        dhcp_cntr_table.increment_counter(config.vlan, "TX", DHCPv4_MESSAGE_TYPE_DROP);
+        return;
+    }
+
     /* Perform padding only when DHCP relay (Option 82) information has been stripped from the packet */
     if(dhcp_pkt->removeOption(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS)) {
         syslog(LOG_NOTICE, "Packet is stripped");
@@ -800,29 +818,9 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
         syslog(LOG_INFO, "[DHCPV4_RELAY] dhcp relay message is broadcast to client %s from server %s",
                config.vlan.c_str(), src_ip.c_str());
         dhcp_cntr_table.increment_counter(config.vlan, "TX", (int)dhcp_pkt->getMessageType());
-    }
-}
-
-/**
- * @code                update_interface_vlan_mapping(std::string interface, std::string vlan, bool is_add);
- *
- * @brief               update interface to vlan mapping and DHCP counter table
- *
- * @param interface     interface name string
- * @param vlan          vlan name string
- * @param is_add        add or delete entry
- *
- * @return              none
- */
-void update_interface_vlan_mapping(std::string interface, std::string vlan, bool is_add) {
-    if (is_add) {
-        vlan_map[interface] = vlan;
-        dhcp_cntr_table.initialize_interface(vlan);
-        syslog(LOG_INFO, "[DHCPV4_RELAY] Add <%s, %s> into interface vlan map\n", interface.c_str(), vlan.c_str());
     } else {
-        vlan_map.erase(interface);
-        dhcp_cntr_table.remove_interface(vlan);
-        syslog(LOG_INFO, "[DHCPV4_RELAY] Remove <%s, %s> from interface vlan map\n", interface.c_str(), vlan.c_str());
+        syslog(LOG_WARNING, "[DHCPV4_RELAY] Failed to send server reply to client on %s\n", config.vlan.c_str());
+        dhcp_cntr_table.increment_counter(config.vlan, "TX", DHCPv4_MESSAGE_TYPE_DROP);
     }
 }
 
@@ -857,7 +855,15 @@ void update_vlan_mapping(std::string vlan, bool is_add) {
     for (auto &itr : keys) {
         auto found = itr.find_last_of('|');
         auto interface = itr.substr(found + 1);
-        update_interface_vlan_mapping(interface, vlan, is_add);
+        if (is_add) {
+            vlan_map[interface] = vlan;
+            dhcp_cntr_table.initialize_interface(vlan);
+            syslog(LOG_INFO, "[DHCPV4_RELAY] Add <%s, %s> into interface vlan map\n", interface.c_str(), vlan.c_str());
+        } else {
+            vlan_map.erase(interface);
+            dhcp_cntr_table.remove_interface(vlan);
+            syslog(LOG_INFO, "[DHCPV4_RELAY] Remove <%s, %s> from interface vlan map\n", interface.c_str(), vlan.c_str());
+        }
     }
 
     /* get VRF attached to the vlan from VLAN_INTERFACE table */
@@ -877,7 +883,11 @@ void update_vlan_mapping(std::string vlan, bool is_add) {
 }
 
 uint16_t ipv4_checksum_cal(const uint8_t* ipv4_header, size_t header_len) {
-    uint8_t header[header_len] = {0};
+    /* IPv4 header: 20 bytes minimum, 60 bytes maximum (with options) */
+    uint8_t header[60] = {0};
+    if (header_len > sizeof(header)) {
+        return 0;
+    }
 
     memcpy(header, ipv4_header, header_len);
     pcpp::iphdr *header_ptr = (pcpp::iphdr *)header;
@@ -994,7 +1004,7 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
         pcpp::EthLayer *eth_layer = raw_pkt.getLayerOfType<pcpp::EthLayer>();
         if (eth_layer == nullptr) {
             syslog(LOG_WARNING, "[DHCPV4_RELAY] Invalid Ethernet packet from interface  %s\n", intf.c_str());
-            if (vlan_id != 0 && !vlan_str.empty()) {
+            if (!vlan_str.empty()) {
                 dhcp_cntr_table.increment_counter(vlan_str, "RX", DHCPv4_MESSAGE_TYPE_MALFORMED);
             }
             continue;
@@ -1003,7 +1013,7 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
         pcpp::IPv4Layer *ip_layer = raw_pkt.getLayerOfType<pcpp::IPv4Layer>();
         if (ip_layer == nullptr) {
             syslog(LOG_WARNING, "[DHCPV4_RELAY] Invalid IP packet from interface  %s\n", intf.c_str());
-            if (vlan_id != 0 && !vlan_str.empty()) {
+            if (!vlan_str.empty()) {
                 dhcp_cntr_table.increment_counter(vlan_str, "RX", DHCPv4_MESSAGE_TYPE_MALFORMED);
             }
             continue;
@@ -1013,7 +1023,7 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
         pcpp::iphdr* ip_hdr = ip_layer->getIPv4Header();
         auto ipv4_checksum = ipv4_checksum_cal((const uint8_t*)ip_hdr, ip_layer->getHeaderLen());
         if (ip_hdr->headerChecksum != htons(ipv4_checksum)) {
-            if (vlan_id != 0 && !vlan_str.empty()) {
+            if (!vlan_str.empty()) {
                 dhcp_cntr_table.increment_counter(vlan_str, "RX", DHCPv4_MESSAGE_TYPE_MALFORMED);
             }
             syslog(LOG_WARNING, "[DHCPV4_RELAY] Checksum failed for IP packet from interface %s\n", intf.c_str());
@@ -1025,7 +1035,7 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
         pcpp::UdpLayer *udp_layer = raw_pkt.getLayerOfType<pcpp::UdpLayer>();
         if (udp_layer == nullptr) {
             syslog(LOG_WARNING, "[DHCPV4_RELAY] Invalid UDP packet from interface  %s\n", intf.c_str());
-            if (vlan_id != 0 && !vlan_str.empty()) {
+            if (!vlan_str.empty()) {
                 dhcp_cntr_table.increment_counter(vlan_str, "RX", DHCPv4_MESSAGE_TYPE_MALFORMED);
             }
             continue;
@@ -1036,7 +1046,7 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
         if (htobe16(udp_checksum) != udp_layer->getUdpHeader()->headerChecksum) {
             syslog(LOG_WARNING, "[DHCPV4_RELAY] UDP checksum validation is failing "
                         " packet is from interface %s\n", intf.c_str());
-            if (vlan_id != 0 && !vlan_str.empty()) {
+            if (!vlan_str.empty()) {
                 dhcp_cntr_table.increment_counter(vlan_str, "RX", DHCPv4_MESSAGE_TYPE_MALFORMED);
             }
             continue;
@@ -1045,7 +1055,7 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
         pcpp::DhcpLayer *dhcp_pkt = raw_pkt.getLayerOfType<pcpp::DhcpLayer>();
         if (dhcp_pkt == nullptr) {
             syslog(LOG_WARNING, "[DHCPV4_RELAY] Invalid DHCP packet from interface  %s\n", intf.c_str());
-            if (vlan_id != 0 && !vlan_str.empty()) {
+            if (!vlan_str.empty()) {
                 dhcp_cntr_table.increment_counter(vlan_str, "RX", DHCPv4_MESSAGE_TYPE_MALFORMED);
             }
             continue;
@@ -1058,7 +1068,9 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
 
             auto config_itr = vlans->find(vlan_str);
             if (config_itr == vlans->end()) {
-                syslog(LOG_WARNING, "[DHCPV4_RELAY] Config not found for vlan %s\n", intf.c_str());
+                syslog(LOG_INFO, "[DHCPV4_RELAY] Relay config not found for %s (interface %s, vlan_id %d)\n",
+                       vlan_str.c_str(), intf.c_str(), vlan_id);
+                dhcp_cntr_table.increment_counter(vlan_str, "RX", DHCPv4_MESSAGE_TYPE_DROP);
                 continue;
             }
             auto config = config_itr->second;
@@ -1069,7 +1081,7 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
         } else if (dhcp_pkt->getDhcpHeader()->opCode == BOOTPREPLY) {
             to_client(dhcp_pkt, vlans, src_ip);
         } else {
-            if (vlan_id != 0 && !vlan_str.empty()) {
+            if (!vlan_str.empty()) {
                 dhcp_cntr_table.increment_counter(vlan_str, "RX", DHCPv4_MESSAGE_TYPE_UNKNOWN);
             }
             continue;
@@ -1216,8 +1228,11 @@ void config_event_callback(evutil_socket_t fd, short event, void *arg) {
     ssize_t bytes_read = read(fd, &received_event, sizeof(received_event));
 
     if (bytes_read == sizeof(received_event)) {
-	    //Do not update the relay configs if dhcp_server is enabled
-        if (((received_event.type == DHCPv4_RELAY_CONFIG_UPDATE) && !feature_dhcp_server_enabled) ||
+        if ((received_event.type == DHCPv4_RELAY_CONFIG_UPDATE) && feature_dhcp_server_enabled) {
+            relay_config *skipped_msg = static_cast<relay_config *>(received_event.msg);
+            delete skipped_msg;
+            return;
+        } else if (((received_event.type == DHCPv4_RELAY_CONFIG_UPDATE) && !feature_dhcp_server_enabled) ||
 	   (received_event.type == DHCPv4_SERVER_RELAY_CONFIG_UPDATE))	{
             relay_config *relay_msg = static_cast<relay_config *>(received_event.msg);
             if (relay_msg) {
@@ -1229,15 +1244,21 @@ void config_event_callback(evutil_socket_t fd, short event, void *arg) {
                         (*vlans)[relay_msg->vlan] = relay_config{};
                         (*vlans)[relay_msg->vlan].vlan = relay_msg->vlan;
                         update_vlan_mapping(relay_msg->vlan, true);
+                        /* Do not early-return on socket failure: continue setting up
+                           servers, VRF, and source interface so the config is complete
+                           when VLAN_INTERFACE_UPDATE creates the socket.
+                           relay_msg is freed at the end of this block */
                         if (prepare_vlan_sockets((*vlans)[relay_msg->vlan]) == -1) {
-                            syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to create Vlan listen socket");
-                            return;
+                            syslog(LOG_NOTICE, "[DHCPV4_RELAY] VLAN socket not ready for %s, will create when IPv4 is assigned\n",
+                                   relay_msg->vlan.c_str());
                         }
                         /* Intially filling the vlan interface IP address. */
                         if (relay_msg->source_interface.empty()) {
                             prepare_relay_interface_config((*vlans)[relay_msg->vlan]);
                         }
                     }
+                    /* Keep struct .vlan in sync with DB (repairs ghosts from INTERFACE_UPDATE ordering). */
+                    (*vlans)[relay_msg->vlan].vlan = relay_msg->vlan;
 
                     if ((*vlans)[relay_msg->vlan].servers != relay_msg->servers) {
                         (*vlans)[relay_msg->vlan].servers = relay_msg->servers;
@@ -1247,6 +1268,7 @@ void config_event_callback(evutil_socket_t fd, short event, void *arg) {
                     /* Compare the existing vrf value and the new DB updated vrf value for vrf modification case. */
                     if ((*vlans)[relay_msg->vlan].vrf != relay_msg->vrf) {
                         if (handle_server_sock((*vlans)[relay_msg->vlan], relay_msg->vrf) < 0) {
+                            delete relay_msg;
                             return;
                         }
                     }
@@ -1284,11 +1306,17 @@ void config_event_callback(evutil_socket_t fd, short event, void *arg) {
         } else if (received_event.type == DHCPv4_RELAY_INTERFACE_UPDATE) {
             relay_config *relay_msg = static_cast<relay_config *>(received_event.msg);
             if (relay_msg) {
+                if (vlans->find(relay_msg->vlan) == vlans->end()) {
+                    syslog(LOG_WARNING, "[DHCPV4_RELAY] Ignoring INTERFACE_UPDATE for unknown VLAN %s\n",
+                                  relay_msg->vlan.c_str());
+                    delete relay_msg;
+                    return;
+                }
                 syslog(LOG_INFO, "[DHCPV4_RELAY] Updating source interface for VLAN %s", relay_msg->vlan.c_str());
                 if (relay_msg->is_add) {
-                    (*vlans)[relay_msg->vlan].src_intf_sel_addr = relay_msg->src_intf_sel_addr;
+                    vlans->at(relay_msg->vlan).src_intf_sel_addr = relay_msg->src_intf_sel_addr;
                 } else {
-                    memset(&(*vlans)[relay_msg->vlan].src_intf_sel_addr, 0, sizeof(sockaddr_in));
+                    memset(&vlans->at(relay_msg->vlan).src_intf_sel_addr, 0, sizeof(sockaddr_in));
                 }
                 delete relay_msg;
             }
@@ -1303,13 +1331,25 @@ void config_event_callback(evutil_socket_t fd, short event, void *arg) {
 
                    if ((*vlans)[msg->vlan].client_sock > 0) {
                        close((*vlans)[msg->vlan].client_sock);
+                       (*vlans)[msg->vlan].client_sock = 0;
                    }
 
-                   update_interface_vlan_mapping(msg->interface, msg->vlan, msg->is_add);
-                   if (prepare_vlan_sockets((*vlans)[msg->vlan]) == -1) {
-                       syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to create Vlan listen socket");
-                       return;
+                   if (msg->is_add) {
+                       vlan_map[msg->interface] = msg->vlan;
+                       dhcp_cntr_table.initialize_interface(msg->vlan);
+                       syslog(LOG_INFO, "[DHCPV4_RELAY] Add <%s, %s> into interface vlan map\n", msg->interface.c_str(), msg->vlan.c_str());
+                   } else {
+                       vlan_map.erase(msg->interface);
+                       dhcp_cntr_table.remove_interface(msg->vlan);
+                       syslog(LOG_INFO, "[DHCPV4_RELAY] Remove <%s, %s> from interface vlan map\n", msg->interface.c_str(), msg->vlan.c_str());
                    }
+                   /* Do not early-return on socket failure: msg is freed
+                      immediately below; no code follows between here and delete. */
+                   if (prepare_vlan_sockets((*vlans)[msg->vlan]) == -1) {
+                       syslog(LOG_NOTICE, "[DHCPV4_RELAY] VLAN socket not ready for %s, will create when IPv4 is assigned\n",
+                              msg->vlan.c_str());
+                   }
+                   prepare_relay_interface_config((*vlans)[msg->vlan]);
                    delete msg;
                }
 	} else if (received_event.type == DHCPv4_RELAY_VLAN_INTERFACE_UPDATE) {
@@ -1326,12 +1366,13 @@ void config_event_callback(evutil_socket_t fd, short event, void *arg) {
                    } else {
                       if ((*vlans)[msg->vlan].client_sock > 0) {
                           close((*vlans)[msg->vlan].client_sock);
+                          (*vlans)[msg->vlan].client_sock = 0;
                       }
                       if (prepare_vlan_sockets((*vlans)[msg->vlan]) == -1) {
-                          syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to create Vlan listen socket");
-                          return;
+                          syslog(LOG_NOTICE, "[DHCPV4_RELAY] VLAN socket not ready for %s, will retry on next event\n",
+                                          msg->vlan.c_str());
                       }
-		      prepare_relay_interface_config((*vlans)[msg->vlan]);
+                      prepare_relay_interface_config((*vlans)[msg->vlan]);
                    }
 
                    std::string value;
@@ -1339,11 +1380,13 @@ void config_event_callback(evutil_socket_t fd, short event, void *arg) {
                                                                     "DHCPV4_RELAY");
                    dhcp_relay_tbl->hget((msg->vlan), SERVER_VRF_FIELD, value);
                    if ((msg->vrf.empty()) || (value.length() != 0)) {
+                       delete msg;
                        return;
                    }
 
                    if ((*vlans)[msg->vlan].vrf != msg->vrf) {
                         if (handle_server_sock((*vlans)[msg->vlan], msg->vrf) < 0) {
+                            delete msg;
                             return;
                         }
                    }

--- a/dhcp4relay/src/dhcp4relay.h
+++ b/dhcp4relay/src/dhcp4relay.h
@@ -109,7 +109,6 @@ struct relay_config {
     sockaddr_in link_address_netmask;
     sockaddr_in src_intf_sel_addr;
     uint32_t link_ifindex;
-    std::shared_ptr<swss::DBConnector> state_db;
     std::string vlan;
     std::string phy_interface;
     std::string vrf;  // This is server VRF.
@@ -123,7 +122,6 @@ struct relay_config {
     std::vector<sockaddr_in> servers_sock;
     bool is_interface_id;
     bool is_add;
-    std::shared_ptr<swss::DBConnector> config_db;
 };
 
 typedef enum {

--- a/dhcp4relay/src/dhcp4relay_mgr.cpp
+++ b/dhcp4relay/src/dhcp4relay_mgr.cpp
@@ -182,7 +182,11 @@ void DHCPMgr::process_device_metadata_notification(std::deque<swss::KeyOpFieldsV
                 std::transform(v.begin(), v.end(), v.begin(), ::tolower);
 		m_config.host_mac_addr = v;
             } else if (f == "deployment_id") {
-		m_config.deployment_id = static_cast<uint32_t>(std::stoul(v));
+                try {
+                    m_config.deployment_id = static_cast<uint32_t>(std::stoul(v));
+                } catch (const std::exception &e) {
+                    syslog(LOG_WARNING, "[DHCPV4_RELAY] Invalid deployment_id value '%s': %s\n", v.c_str(), e.what());
+                }
             } else if (f == "subtype") {
                 subtype_found = true;
                 subtype_value = v;
@@ -369,7 +373,12 @@ void DHCPMgr::process_relay_notification(std::deque<swss::KeyOpFieldsValuesTuple
                 } else if (f == "agent_relay_mode") {
                     relay_msg->agent_relay_mode = v;
                 } else if (f == "max_hop_count") {
-                    relay_msg->max_hop_count = static_cast<uint8_t>(std::stoi(v));
+                    try {
+                        relay_msg->max_hop_count = static_cast<uint8_t>(std::stoi(v));
+                    } catch (const std::exception &e) {
+                        syslog(LOG_WARNING, "[DHCPV4_RELAY] Invalid max_hop_count value '%s' for VLAN %s: %s\n",
+                               v.c_str(), vlan.c_str(), e.what());
+                    }
                 }
                 syslog(LOG_DEBUG, "[DHCPV4_RELAY] key: %s, Operation: %s, f: %s, v: %s", vlan.c_str(), operation.c_str(), f.c_str(), v.c_str());
             }
@@ -398,6 +407,7 @@ void DHCPMgr::process_relay_notification(std::deque<swss::KeyOpFieldsValuesTuple
 
         if (relay_msg->servers.empty() && operation != "DEL") {
             syslog(LOG_WARNING, "[DHCPV4_RELAY] No servers found for VLAN %s, skipping configuration.", vlan.c_str());
+            delete relay_msg;
             continue;
         }
         syslog(LOG_INFO, "[DHCPV4_RELAY] %s %s relay config\n", operation.c_str(), vlan.c_str());
@@ -724,6 +734,7 @@ void DHCPMgr::process_dhcp_server_ipv4_notification(std::deque<swss::KeyOpFields
                      syslog(LOG_INFO, "[DHCPV4_RELAY] Fetched DHCPv4 server IP from STATE_DB: %s", ip.c_str());
                   } else {
                      syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to get DHCPv4 server IP from STATE_DB");
+                     delete relay_msg;
                      continue;
                   }
               }

--- a/dhcp4relay/src/dhcp4relay_stats.cpp
+++ b/dhcp4relay/src/dhcp4relay_stats.cpp
@@ -73,7 +73,12 @@ void update_interface_counters_in_db(
 
     // Populate existing counters
     for (const auto& field : existing_fields) {
-        counter_map[fvField(field)] = std::stoi(fvValue(field));
+        try {
+            counter_map[fvField(field)] = std::stoi(fvValue(field));
+        } catch (const std::exception &e) {
+            syslog(LOG_WARNING, "[DHCPV4_RELAY] update_interface_counters_in_db: invalid counter value '%s' for field '%s': %s\n",
+                   fvValue(field).c_str(), fvField(field).c_str(), e.what());
+        }
     }
 
     // Update with new values
@@ -198,12 +203,26 @@ void DHCPCounter_table::initialize_interface(const std::string& interface) {
 void DHCPCounter_table::increment_counter(const std::string& interface,
                                         const std::string& direction,
                                         int msg_type) {
-    std::string type = counter_map.find(msg_type)->second;
-    // Initialize counters if not present
-    if (interfaces_cntr_table.find(interface) == interfaces_cntr_table.end())
-        DHCPCounter_table::initialize_interface(interface);
+    auto type_itr = counter_map.find(msg_type);
+    if (type_itr == counter_map.end()) {
+        syslog(LOG_WARNING, "[DHCPV4_RELAY] increment_counter: unknown msg_type %d, counting as Unknown\n", msg_type);
+        type_itr = counter_map.find(DHCPv4_MESSAGE_TYPE_UNKNOWN);
+        if (type_itr == counter_map.end()) {
+            return;
+        }
+    }
+    const std::string &type = type_itr->second;
 
     std::lock_guard<std::mutex> lock(interfaces_mutex);
+
+    if (interfaces_cntr_table.find(interface) == interfaces_cntr_table.end()) {
+        DHCPCounters counter;
+        for (const auto& t : counter_map) {
+            counter.RX[t.second] = 0;
+            counter.TX[t.second] = 0;
+        }
+        interfaces_cntr_table[interface] = counter;
+    }
 
     if (direction == "RX") {
         interfaces_cntr_table[interface].RX[type]++;

--- a/dhcp4relay/test/mock_relay.cpp
+++ b/dhcp4relay/test/mock_relay.cpp
@@ -333,8 +333,11 @@ TEST(relayConfig, handle_interface_events) {
                      .Times(AtLeast(1))
                      .WillRepeatedly(Invoke(RealWrite));
     ASSERT_NE(pipe(pipe_fds), -1);
-    relay_config *config = new relay_config();
+
     std::unordered_map<std::string, relay_config> vlans;
+    vlans["Vlan100"].vlan = "Vlan100";
+
+    relay_config *config = new relay_config();
     config->vlan = "Vlan100";
     config->is_add = true;
     config->src_intf_sel_addr.sin_family = AF_INET;
@@ -370,8 +373,41 @@ TEST(relayConfig, handle_interface_events) {
     close(pipe_fds[1]);
 }
 
-TEST(relayConfig, handle_vlan_member_events) {
+TEST(relayConfig, handle_interface_events_unknown_vlan) {
     int pipe_fds[2];
+    EXPECT_GLOBAL_CALL(write, write(_, _, _))
+                     .Times(AtLeast(1))
+                     .WillRepeatedly(Invoke(RealWrite));
+    ASSERT_NE(pipe(pipe_fds), -1);
+
+    std::unordered_map<std::string, relay_config> vlans;
+
+    relay_config *config = new relay_config();
+    config->vlan = "Vlan999";
+    config->is_add = true;
+    config->src_intf_sel_addr.sin_family = AF_INET;
+    config->src_intf_sel_addr.sin_addr.s_addr = inet_addr("10.0.0.1");
+
+    event_config event;
+    event.type = DHCPv4_RELAY_INTERFACE_UPDATE;
+    event.msg = static_cast<void *>(config);
+
+    ASSERT_NE(write(pipe_fds[1], &event, sizeof(event)), -1);
+
+    config_event_callback(pipe_fds[0], 0, &vlans);
+
+    EXPECT_TRUE(vlans.find("Vlan999") == vlans.end());
+
+    close(pipe_fds[0]);
+    close(pipe_fds[1]);
+}
+
+TEST(relayConfig, handle_vlan_member_events) {
+    struct ifaddrs *mock_ifaddrs = CreateMockIfaddrs("192.168.1.1", "255.255.255.0", "Vlan100", "192.168.1.2", "Ethernet4");
+    int pipe_fds[2];
+    EXPECT_GLOBAL_CALL(getifaddrs, getifaddrs(_))
+        .WillRepeatedly(DoAll(testing::SetArgPointee<0>(mock_ifaddrs), Return(0)));
+    EXPECT_GLOBAL_CALL(freeifaddrs, freeifaddrs(_)).Times(AtLeast(2));
     EXPECT_GLOBAL_CALL(write, write(_, _, _))
                      .Times(AtLeast(1))
                      .WillRepeatedly(Invoke(RealWrite));
@@ -417,6 +453,7 @@ TEST(relayConfig, handle_vlan_member_events) {
 
     close(pipe_fds[0]);
     close(pipe_fds[1]);
+    FreeMockIfaddrs(mock_ifaddrs);
 }
 
 TEST(relayConfig, handle_vlan_interface_events) {


### PR DESCRIPTION
## Summary of changes

Memory leak and resource-management fixes
-----------------------------------------
- to_client(): freeifaddrs() on every early-return path (giaddr==0, missing circuit-id) -- previously leaked the full ifaddr list per BOOTREPLY, which on a config with a DHCPv4 helper on a VLAN with no IPv4 address could cause RSS to grow to multiple GB and ultimately trigger a kernel panic.
- from_client(): drop the packet (with TX-drop counter increment) when giaddr is still 0 after attempting to set it (no IPv4 on SVI).
- prepare_vrf_sockets(): check bind() return value, close the socket on failure, and properly reuse the existing VRF socket (assign itr->second.sock and bump ref_count) instead of returning -1.
- from_client(): bounds-check config.servers[index] before logging (use "<unknown>" fallback) to prevent OOB when servers and servers_sock diverge.
- Add missing delete relay_msg / delete msg on every error-return path in config_event_callback() and the manager's relay/server/dhcp_server notification processors.
- Wrap std::stoi/stoul calls in try/catch in process_relay_notification, process_device_metadata_notification, and update_interface_counters_in_db to prevent worker-thread crashes on malformed DB values.
- increment_counter(): null-check counter_map.find() result before dereferencing; move per-interface initialization inside the mutex to fix a TOCTOU race.

Quality / stability fixes
-------------------------
- prepare_relay_interface_config(): zero-initialize intf_addr, net_mask and src_intf_sel sockaddr_in. Without this, when a VLAN had no IPv4 address the structs contained stack garbage; a non-zero giaddr could bypass the giaddr==0 guard in to_client() and cause server replies to be dropped or misdirected.
- to_client(): replace exit(1) with return on getifaddrs() failure (don't kill the daemon on a transient error -- just drop the packet).

Option 82 encoding fix (DHCP client could not get an address) 
-------------------------------------------------------------
- DHCPv4_RELAY_CONFIG_UPDATE: keep (*vlans)[relay_msg->vlan].vlan in sync with the DB, repairing "ghost" entries created by an out-of-order INTERFACE_UPDATE (whose blank fields then leaked into Option 82).
- DHCPv4_RELAY_INTERFACE_UPDATE: ignore the event entirely if the VLAN is unknown (prevents creating a default-constructed map entry).
- DHCPv4_RELAY_VLAN_INTERFACE_ADD: call prepare_relay_interface_config() immediately after socket creation so Option 82 fields are populated before the first packet arrives.
- DHCPv4_RELAY_VLAN_INTERFACE_UPDATE: don't return from the whole callback when prepare_vlan_sockets() fails -- log NOTICE and continue (will retry on the next event).