### PR TITLE
[dhcp4relay] Migrate syslog() to SWSS_LOG macros for runtime log-level control

### DIFF
--- a/dhcp4relay/src/dhcp4_sender.cpp
+++ b/dhcp4relay/src/dhcp4_sender.cpp
@@ -2,7 +2,7 @@
 
 #include <arpa/inet.h>
 #include <errno.h>
-#include <syslog.h>
+#include "logger.h"
 
 #include <cstring>
 
@@ -63,14 +63,14 @@ bool send_udp(int sock, uint8_t *buffer, struct sockaddr_in target, uint32_t len
         if (sendmsg(sock, &msg, 0) == -1) {
             char server_addr[INET_ADDRSTRLEN];
             inet_ntop(AF_INET, &(target.sin_addr), server_addr, INET_ADDRSTRLEN);
-            syslog(LOG_ERR, "sendmsg: Failed to send to target address: %s, error: %s\n", server_addr, strerror(errno));
+            SWSS_LOG_ERROR("sendmsg: Failed to send to target address: %s, error: %s", server_addr, strerror(errno));
             return false;
         }
     } else {
         if (sendto(sock, buffer, len, 0, (const struct sockaddr *)&target, sizeof(target)) == -1) {
             char server_addr[INET_ADDRSTRLEN];
             inet_ntop(AF_INET, &(target.sin_addr), server_addr, INET_ADDRSTRLEN);
-            syslog(LOG_ERR, "sendto: Failed to send to target address: %s, error: %s\n", server_addr, strerror(errno));
+            SWSS_LOG_ERROR("sendto: Failed to send to target address: %s, error: %s", server_addr, strerror(errno));
             return false;
         }
     }

--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -111,7 +111,7 @@ std::shared_ptr<swss::DBConnector> state_db = std::make_shared<swss::DBConnector
 int sock_open(const struct sock_fprog *fprog) {
     int s = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
     if (s == -1) {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] socket: Failed to create socket with error %s\n", strerror(errno));
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] socket: Failed to create socket with error %s", strerror(errno));
         return -1;
     }
 
@@ -125,12 +125,12 @@ int sock_open(const struct sock_fprog *fprog) {
     };
 
     if (bind(s, (struct sockaddr *)&sll, sizeof sll) == -1) {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] bind: Failed to bind to specified interface, error: %s\n", strerror(errno));
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] bind: Failed to bind to specified interface, error: %s", strerror(errno));
         (void)close(s);
         return -1;
     }
     if (fprog && setsockopt(s, SOL_SOCKET, SO_ATTACH_FILTER, fprog, sizeof *fprog) == -1) {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] setsockopt: Failed to attach filter, error: %s\n", strerror(errno));
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] setsockopt: Failed to attach filter, error: %s", strerror(errno));
         (void)close(s);
         return -1;
     }
@@ -138,30 +138,30 @@ int sock_open(const struct sock_fprog *fprog) {
     int optval = 0;
     socklen_t optlen = sizeof(optval);
     if (getsockopt(s, SOL_SOCKET, SO_RCVBUF, &optval, &optlen) == -1) {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] getsockopt: Failed to get recv buffer size, error:  %s\n", strerror(errno));
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] getsockopt: Failed to get recv buffer size, error:  %s", strerror(errno));
         (void)close(s);
         return -1;
     }
 
     int optval_new = RAWSOCKET_RECV_SIZE;
     if (setsockopt(s, SOL_SOCKET, SO_RCVBUF, &optval_new, sizeof(optval_new)) == -1) {
-        syslog(LOG_WARNING, "[DHCPV4_RELAY] setsockopt: Failed to set recv buffer size to %d, use default value\n", optval_new);
+        SWSS_LOG_WARN("[DHCPV4_RELAY] setsockopt: Failed to set recv buffer size to %d, use default value", optval_new);
     } else {
-        syslog(LOG_INFO, "[DHCPV4_RELAY] setsockopt: change raw socket recv buffer size from %d to %d\n", optval, optval_new);
+        SWSS_LOG_INFO("[DHCPV4_RELAY] setsockopt: change raw socket recv buffer size from %d to %d", optval, optval_new);
     }
 
     optval = 1;
     if (setsockopt(s, SOL_PACKET, PACKET_AUXDATA, &optval, sizeof(optval)) == -1) {
-        syslog(LOG_WARNING, "[DHCPV4_RELAY] setsockopt: Failed to set packet AUXDATA \n");
+        SWSS_LOG_WARN("[DHCPV4_RELAY] setsockopt: Failed to set packet AUXDATA ");
         (void)close(s);
         return -1;
     }
 
     int ignore_outgoing = 1;
     if (setsockopt(s, SOL_PACKET, PACKET_IGNORE_OUTGOING, &ignore_outgoing, sizeof(ignore_outgoing)) == -1) {
-        syslog(LOG_WARNING, "[DHCPV4_RELAY] setsockopt: Failed to ignore outgoing \n");
+        SWSS_LOG_WARN("[DHCPV4_RELAY] setsockopt: Failed to ignore outgoing ");
     } else {
-        syslog(LOG_INFO, "[DHCPV4_RELAY] setsockopt: outgoing packet is ignored\n");
+        SWSS_LOG_INFO("[DHCPV4_RELAY] setsockopt: outgoing packet is ignored");
     }
 
     return s;
@@ -171,7 +171,7 @@ void prepare_relay_server_config(relay_config &interface_config) {
     for (auto server : interface_config.servers) {
         sockaddr_in tmp;
         if (inet_pton(AF_INET, server.c_str(), &tmp.sin_addr) != 1) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] inet_pton: Failed to convert IPv4 address\n");
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] inet_pton: Failed to convert IPv4 address");
             return;
         }
         tmp.sin_family = AF_INET;
@@ -256,7 +256,7 @@ void prepare_relay_interface_config(relay_config &interface_config) {
     bool source_intf_sel_opt = false;
 
     if (getifaddrs(&ifa) == -1) {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] getifaddrs: Unable to get network interfaces, error: %s\n", strerror(errno));
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] getifaddrs: Unable to get network interfaces, error: %s", strerror(errno));
         return;
     }
 
@@ -264,13 +264,12 @@ void prepare_relay_interface_config(relay_config &interface_config) {
         /* If DualTor is enabled, we set source interface to "Loopback0"
            and link_selection option will be enabled during encoding if is_dualTor is enabled */
         interface_config.source_interface = "Loopback0";
-        syslog(LOG_INFO,
-               "[DHCPV4_INFO][DualTor] %s: link_selection_opt is enabled and source interface is set to %s\n",
+        SWSS_LOG_INFO("[DHCPV4_INFO][DualTor] %s: link_selection_opt is enabled and source interface is set to %s",
                interface_config.vlan.c_str(), interface_config.source_interface.c_str());
     }
 
     if (interface_config.source_interface.length() > 0) {
-        syslog(LOG_INFO, "[DHCPV4_INFO] source interface addr is set to %s\n",
+        SWSS_LOG_INFO("[DHCPV4_INFO] source interface addr is set to %s",
                interface_config.source_interface.c_str());
     } else {
         /* This flag is used to make sure source interface address is copied to config cache
@@ -318,7 +317,7 @@ int prepare_vrf_sockets(relay_config &config) {
         /* Vrf sock is not available in map need to create */
         vrf_sock = socket(AF_INET, SOCK_DGRAM, 0);
         if (vrf_sock == -1) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] socket: Failed to create client_addr socket vrf %s err = %s\n",
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] socket: Failed to create client_addr socket vrf %s err = %s",
                    config.vrf.c_str(), strerror(errno));
             return -1;
         }
@@ -329,7 +328,7 @@ int prepare_vrf_sockets(relay_config &config) {
         if (config.vrf != "default") {
             if (setsockopt(vrf_sock, SOL_SOCKET, SO_BINDTODEVICE,
                            config.vrf.c_str(), strlen(config.vrf.c_str())) < 0) {
-                syslog(LOG_ERR, "[DHCPV4_RELAY] setsockopt: Failed to bind socket to %s VRF err = %s\n",
+                SWSS_LOG_ERROR("[DHCPV4_RELAY] setsockopt: Failed to bind socket to %s VRF err = %s",
                        config.vrf.c_str(), strerror(errno));
                 close(vrf_sock);
                 return -1;
@@ -342,7 +341,7 @@ int prepare_vrf_sockets(relay_config &config) {
         addr.sin_addr.s_addr = htonl(INADDR_ANY);
         addr.sin_port = htons(RELAY_PORT);
         if (bind(vrf_sock, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] bind: Failed to bind vrf socket for %s, error: %s\n",
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] bind: Failed to bind vrf socket for %s, error: %s",
                    config.vrf.c_str(), strerror(errno));
             close(vrf_sock);
             return -1;
@@ -378,7 +377,7 @@ int prepare_vlan_sockets(relay_config &config) {
     bool bind_client_addr = false;
 
     if (getifaddrs(&ifa) == -1) {
-        syslog(LOG_WARNING, "[DHCPV4_RELAY] getifaddrs: Unable to get network interfaces with %s\n", strerror(errno));
+        SWSS_LOG_WARN("[DHCPV4_RELAY] getifaddrs: Unable to get network interfaces with %s", strerror(errno));
         return -1;
     }
 
@@ -401,13 +400,13 @@ int prepare_vlan_sockets(relay_config &config) {
     freeifaddrs(ifa);
 
     if (!bind_client_addr) {
-        syslog(LOG_NOTICE, "[DHCPV4_RELAY] No IPv4 address on interface %s, deferring socket creation\n", config.vlan.c_str());
+        SWSS_LOG_NOTICE("[DHCPV4_RELAY] No IPv4 address on interface %s, deferring socket creation", config.vlan.c_str());
         return -1;
     }
 
     int client_sock = 0;
     if ((client_sock = socket(AF_INET, SOCK_DGRAM, 0)) == -1) {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] socket: Failed to create client_addr socket on interface %s, error: %s\n",
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] socket: Failed to create client_addr socket on interface %s, error: %s",
                config.vlan.c_str(), strerror(errno));
         return -1;
     }
@@ -418,14 +417,14 @@ int prepare_vlan_sockets(relay_config &config) {
     /* Bind client socket to vlan interface */
     if (setsockopt(client_sock, SOL_SOCKET, SO_BINDTODEVICE, config.vlan.c_str(),
                    strlen(config.vlan.c_str())) < 0) {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] failed to bind client_sock to vlan %s, error: %s\n",
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] failed to bind client_sock to vlan %s, error: %s",
                config.vlan.c_str(), strerror(errno));
         close(client_sock);
         return -1;
     }
 
     if (bind(client_sock, (sockaddr *)&client_addr, sizeof(client_addr)) == -1) {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] bind: Failed to bind socket to IPv4 address on interface %s: %s\n",
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] bind: Failed to bind socket to IPv4 address on interface %s: %s",
                config.vlan.c_str(), strerror(errno));
         close(client_sock);
         return -1;
@@ -433,7 +432,7 @@ int prepare_vlan_sockets(relay_config &config) {
 
     int broadcast_enable = 1;
     if (setsockopt(client_sock, SOL_SOCKET, SO_BROADCAST, &broadcast_enable, sizeof(broadcast_enable)) < 0) {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] setsockopt: Failed to set socket to receive broadcast address, error: %s\n",
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] setsockopt: Failed to set socket to receive broadcast address, error: %s",
                strerror(errno));
         close(client_sock);
         return -1;
@@ -441,9 +440,8 @@ int prepare_vlan_sockets(relay_config &config) {
 
     int optval = 1;
     if (setsockopt(client_sock, IPPROTO_IP, IP_PKTINFO, &optval, sizeof(optval)) < 0) {
-        syslog(LOG_ERR,
-               "[DHCPV4_RELAY] setsockopt: Failed to set socket option to "
-               "get IP PKT information, error: %s\n",
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] setsockopt: Failed to set socket option to "
+               "get IP PKT information, error: %s",
                strerror(errno));
         close(client_sock);
         return -1;
@@ -466,7 +464,7 @@ std::string get_mac_address(const std::string &ifname) {
     std::string path = "/sys/class/net/" + ifname + "/address";
     std::ifstream file(path);
     if (!file.is_open()) {
-        syslog(LOG_ERR, "Fetching mac address for interface %s", ifname.c_str());
+        SWSS_LOG_ERROR("Fetching mac address for interface %s", ifname.c_str());
         return "";
     }
     std::string mac;
@@ -550,8 +548,7 @@ void encode_relay_option(pcpp::DhcpLayer *dhcp_pkt, relay_config *config) {
 
     /* We shouldn't append relay information if packet size is exceeding MTU size */
     if ((dhcp_pkt->getHeaderLen() + buf_offset) > MAX_DHCP_PKT_SIZE) {
-        syslog(LOG_ERR,
-               "[DHCPV4_RELAY] %ld packet size is exceeding allowed size %d"
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] %ld packet size is exceeding allowed size %d"
                " from interface %s",
                (dhcp_pkt->getHeaderLen() + buf_offset),
                MAX_DHCP_PKT_SIZE, config->vlan.c_str());
@@ -585,7 +582,7 @@ void from_client(pcpp::DhcpLayer *dhcp_pkt, relay_config &config) {
                 config.link_address.sin_addr.s_addr;
         }
         if (!(dhcp_pkt->getDhcpHeader()->gatewayIpAddress)) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] No IPv4 address configured on %s,\n"
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] No IPv4 address configured on %s,"
                    " dropping DHCP packet. Configure an IPv4 address on the VLAN"
                    " interface for relay to function", config.vlan.c_str());
             dhcp_cntr_table.increment_counter(config.vlan, "TX", DHCPv4_MESSAGE_TYPE_DROP);
@@ -593,7 +590,7 @@ void from_client(pcpp::DhcpLayer *dhcp_pkt, relay_config &config) {
         }
         if ((dhcp_pkt->getDhcpHeader()->magicNumber) &&
             (dhcp_pkt->getDhcpHeader()->magicNumber) == DHCP_MAGIC_NUMBER) {
-            syslog(LOG_WARNING, "[DHCPV4_RELAY] encode DHCP relay option");
+            SWSS_LOG_WARN("[DHCPV4_RELAY] encode DHCP relay option");
             encode_relay_option(dhcp_pkt, &config);
         }
     } else {
@@ -614,7 +611,7 @@ void from_client(pcpp::DhcpLayer *dhcp_pkt, relay_config &config) {
         } else {
             /* discard: explicit "discard" value or any unrecognized value */
             dhcp_cntr_table.increment_counter(config.vlan, "TX", DHCPv4_MESSAGE_TYPE_DROP);
-            syslog(LOG_INFO, "[DHCPV4_RELAY] agent relay mode is discard, dropping the packet %s",
+            SWSS_LOG_INFO("[DHCPV4_RELAY] agent relay mode is discard, dropping the packet %s",
                    config.vlan.c_str());
             return;
         }
@@ -622,7 +619,7 @@ void from_client(pcpp::DhcpLayer *dhcp_pkt, relay_config &config) {
 
     /* Drop the packet if the hop count exceeds the configured maximum. */
     if (dhcp_pkt->getDhcpHeader()->hops >= config.max_hop_count) {
-        syslog(LOG_NOTICE, "[DHCPV4_RELAY] Dropping packet: hop count %d exceeds max allowed %d\n",
+        SWSS_LOG_NOTICE("[DHCPV4_RELAY] Dropping packet: hop count %d exceeds max allowed %d",
                dhcp_pkt->getDhcpHeader()->hops, config.max_hop_count);
         // increment drop counter
         dhcp_cntr_table.increment_counter(config.vlan, "TX", DHCPv4_MESSAGE_TYPE_DROP);
@@ -645,11 +642,11 @@ void from_client(pcpp::DhcpLayer *dhcp_pkt, relay_config &config) {
     for (auto server : config.servers_sock) {
         const char *server_str = (index < config.servers.size()) ? config.servers[index].c_str() : "<unknown>";
         if (send_udp(sock, (uint8_t *)dhcp_pkt->getDhcpHeader(), server, dhcp_pkt->getHeaderLen(), src_ip, use_intf_ip_as_src_ip, true)) {
-            syslog(LOG_INFO, "[DHCPV4_RELAY] DHCP packet is sent to configured server: %s, interface: %s",
+            SWSS_LOG_INFO("[DHCPV4_RELAY] DHCP packet is sent to configured server: %s, interface: %s",
                    server_str, config.vlan.c_str());
             dhcp_cntr_table.increment_counter(config.vlan, "TX", (int)dhcp_pkt->getMessageType());
         } else {
-            syslog(LOG_NOTICE, "[DHCPV4_RELAY] DHCP packet sending FAILED for configured server: %s, interface: %s",
+            SWSS_LOG_NOTICE("[DHCPV4_RELAY] DHCP packet sending FAILED for configured server: %s, interface: %s",
                    server_str, config.vlan.c_str());
             // increment drop counter
             dhcp_cntr_table.increment_counter(config.vlan, "TX", DHCPv4_MESSAGE_TYPE_DROP);
@@ -667,14 +664,14 @@ uint8_t *decode_tlv(const uint8_t *buf, uint8_t t, uint8_t &l, uint32_t options_
         len = *(temp + DHCP_SUB_OPT_TLV_LENGTH_OFFSET);
         if ((offset + DHCP_SUB_OPT_TLV_LENGTH_OFFSET + len) > options_total_size) {
             /* Malformed packet */
-            syslog(LOG_ERR, "[DHCPV4_INFO] Failed to decode relay agent sub-option %d"
-                       " exceeded total option len %d offset %d sub-option len %d\n",
+            SWSS_LOG_ERROR("[DHCPV4_INFO] Failed to decode relay agent sub-option %d"
+                       " exceeded total option len %d offset %d sub-option len %d",
                        t, options_total_size, offset, len);
             l = 0;
             return NULL;
         }
         if (t == *temp) {
-            syslog(LOG_INFO, "[DHCPV4_INFO] Decoding relay agent sub-option %d of len %d\n", t, len);
+            SWSS_LOG_INFO("[DHCPV4_INFO] Decoding relay agent sub-option %d of len %d", t, len);
             l = len;
             return (temp + DHCP_SUB_OPT_TLV_HEADER_LEN);
         }
@@ -706,13 +703,13 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
     std::unordered_map<std::string, relay_config>::iterator config_itr = vlans->end();
 
     if (getifaddrs(&ifa) == -1) {
-        syslog(LOG_WARNING, "[DHCPV4_RELAY] getifaddrs: Unable to get network interfaces, error: %s\n", strerror(errno));
+        SWSS_LOG_WARN("[DHCPV4_RELAY] getifaddrs: Unable to get network interfaces, error: %s", strerror(errno));
         return;
     }
 
     /* Return if giaddr is empty */
     if (giaddr == 0) {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] Message received with empty giaddr from server %s\n",
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] Message received with empty giaddr from server %s",
                src_ip.c_str());
         freeifaddrs(ifa);
         return;
@@ -728,9 +725,8 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
         auto circuit_id_ptr = decode_tlv((const uint8_t *)options_ptr, OPTION82_SUBOPT_CIRCUIT_ID,
                 circuit_id_len, agent_option_size);
         if (circuit_id_ptr == NULL) {
-            syslog(LOG_ERR,
-                    "[DHCPV4_RELAY] Circuit id sub-option is missing in relay"
-                    " agent option from server %s\n",
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Circuit id sub-option is missing in relay"
+                    " agent option from server %s",
                     src_ip.c_str());
             freeifaddrs(ifa);
             return;
@@ -747,9 +743,8 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
         if (vlan_interface.length() > 0) {
             config_itr = vlans->find(vlan_interface);
             if (config_itr == vlans->end()) {
-                syslog(LOG_INFO,
-                        "[DHCPV4_RELAY] Vlan config not found for the circuit"
-                        "id encoded interface  %s\n",
+                SWSS_LOG_INFO("[DHCPV4_RELAY] Vlan config not found for the circuit"
+                        "id encoded interface  %s",
                         vlan_interface.c_str());
             }
         }
@@ -773,7 +768,7 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
         freeifaddrs(ifa);
 
         if (intf_name.length() == 0) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to find interface attached to address %u\n", giaddr);
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to find interface attached to address %u", giaddr);
             return;
         }
 
@@ -783,7 +778,7 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
         /* Expecting interface is SVI interface of vlan */
         config_itr = vlans->find(intf_name);
         if (config_itr == vlans->end()) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Config not found for vlan %s\n", intf_name.c_str());
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Config not found for vlan %s", intf_name.c_str());
             dhcp_cntr_table.increment_counter(intf_name, "RX", DHCPv4_MESSAGE_TYPE_DROP);
             return;
         }
@@ -803,7 +798,7 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
     /* TODO: Send unicast message to client if BOOTP flag from client is set to unicast */
 
     if (config.client_sock <= 0) {
-        syslog(LOG_WARNING, "[DHCPV4_RELAY] Dropping server reply for %s: VLAN socket not ready (no IPv4 address)\n",
+        SWSS_LOG_WARN("[DHCPV4_RELAY] Dropping server reply for %s: VLAN socket not ready (no IPv4 address)",
                config.vlan.c_str());
         dhcp_cntr_table.increment_counter(config.vlan, "TX", DHCPv4_MESSAGE_TYPE_DROP);
         return;
@@ -811,16 +806,16 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
 
     /* Perform padding only when DHCP relay (Option 82) information has been stripped from the packet */
     if(dhcp_pkt->removeOption(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS)) {
-        syslog(LOG_NOTICE, "Packet is stripped");
+        SWSS_LOG_NOTICE("Packet is stripped");
         pad = true;
     }
 
     if (send_udp(config.client_sock, (uint8_t *)dhcp_pkt->getDhcpHeader(), target_addr, dhcp_pkt->getHeaderLen(), ip_zero, false, pad)) {
-        syslog(LOG_INFO, "[DHCPV4_RELAY] dhcp relay message is broadcast to client %s from server %s",
+        SWSS_LOG_INFO("[DHCPV4_RELAY] dhcp relay message is broadcast to client %s from server %s",
                config.vlan.c_str(), src_ip.c_str());
         dhcp_cntr_table.increment_counter(config.vlan, "TX", (int)dhcp_pkt->getMessageType());
     } else {
-        syslog(LOG_WARNING, "[DHCPV4_RELAY] Failed to send server reply to client on %s\n", config.vlan.c_str());
+        SWSS_LOG_WARN("[DHCPV4_RELAY] Failed to send server reply to client on %s", config.vlan.c_str());
         dhcp_cntr_table.increment_counter(config.vlan, "TX", DHCPv4_MESSAGE_TYPE_DROP);
     }
 }
@@ -840,11 +835,11 @@ void update_interface_vlan_mapping(std::string interface, std::string vlan, bool
     if (is_add) {
         vlan_map[interface] = vlan;
         dhcp_cntr_table.initialize_interface(vlan);
-        syslog(LOG_INFO, "[DHCPV4_RELAY] Add <%s, %s> into interface vlan map\n", interface.c_str(), vlan.c_str());
+        SWSS_LOG_INFO("[DHCPV4_RELAY] Add <%s, %s> into interface vlan map", interface.c_str(), vlan.c_str());
     } else {
         vlan_map.erase(interface);
         dhcp_cntr_table.remove_interface(vlan);
-        syslog(LOG_INFO, "[DHCPV4_RELAY] Remove <%s, %s> from interface vlan map\n", interface.c_str(), vlan.c_str());
+        SWSS_LOG_INFO("[DHCPV4_RELAY] Remove <%s, %s> from interface vlan map", interface.c_str(), vlan.c_str());
     }
 }
 
@@ -961,7 +956,7 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
         auto buffer_sz = recvmsg(fd, &msg, 0);
         if (buffer_sz <= 0) {
             if (errno != EAGAIN) {
-                syslog(LOG_ERR, "[DHCPV4_RELAY] recv: Failed to receive data at filter socket: %s\n", strerror(errno));
+                SWSS_LOG_ERROR("[DHCPV4_RELAY] recv: Failed to receive data at filter socket: %s", strerror(errno));
             }
             return;
         }
@@ -980,7 +975,7 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
         }
 
         if (if_indextoname(sll->sll_ifindex, interface_name) == NULL) {
-            syslog(LOG_WARNING, "[DHCPV4_RELAY] Invalid input interface index %d\n", sll->sll_ifindex);
+            SWSS_LOG_WARN("[DHCPV4_RELAY] Invalid input interface index %d", sll->sll_ifindex);
             continue;
         }
         std::string intf(interface_name);
@@ -997,7 +992,7 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
             auto vlan = vlan_map.find(intf);
             if (vlan == vlan_map.end()) {
                 if (intf.find(CLIENT_IF_PREFIX) != std::string::npos) {
-                    syslog(LOG_WARNING, "[DHCPV4_RELAY] Invalid input interface %s\n", interface_name);
+                    SWSS_LOG_WARN("[DHCPV4_RELAY] Invalid input interface %s", interface_name);
                 } else if ((m_config.is_SmartSwitch) && (intf.rfind("dpu", 0) == 0) && !m_config.midplane_bridge.empty()) {
                     // if its SmartSwitch, we need to check for bridge_midplane interface
                     vlan_str = m_config.midplane_bridge;
@@ -1019,7 +1014,7 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
         /* Extract packets in each layers */
         pcpp::EthLayer *eth_layer = raw_pkt.getLayerOfType<pcpp::EthLayer>();
         if (eth_layer == nullptr) {
-            syslog(LOG_WARNING, "[DHCPV4_RELAY] Invalid Ethernet packet from interface  %s\n", intf.c_str());
+            SWSS_LOG_WARN("[DHCPV4_RELAY] Invalid Ethernet packet from interface  %s", intf.c_str());
             if (!vlan_str.empty()) {
                 dhcp_cntr_table.increment_counter(vlan_str, "RX", DHCPv4_MESSAGE_TYPE_MALFORMED);
             }
@@ -1028,7 +1023,7 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
 
         pcpp::IPv4Layer *ip_layer = raw_pkt.getLayerOfType<pcpp::IPv4Layer>();
         if (ip_layer == nullptr) {
-            syslog(LOG_WARNING, "[DHCPV4_RELAY] Invalid IP packet from interface  %s\n", intf.c_str());
+            SWSS_LOG_WARN("[DHCPV4_RELAY] Invalid IP packet from interface  %s", intf.c_str());
             if (!vlan_str.empty()) {
                 dhcp_cntr_table.increment_counter(vlan_str, "RX", DHCPv4_MESSAGE_TYPE_MALFORMED);
             }
@@ -1042,7 +1037,7 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
             if (!vlan_str.empty()) {
                 dhcp_cntr_table.increment_counter(vlan_str, "RX", DHCPv4_MESSAGE_TYPE_MALFORMED);
             }
-            syslog(LOG_WARNING, "[DHCPV4_RELAY] Checksum failed for IP packet from interface %s\n", intf.c_str());
+            SWSS_LOG_WARN("[DHCPV4_RELAY] Checksum failed for IP packet from interface %s", intf.c_str());
             continue;
         }
 
@@ -1050,7 +1045,7 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
 
         pcpp::UdpLayer *udp_layer = raw_pkt.getLayerOfType<pcpp::UdpLayer>();
         if (udp_layer == nullptr) {
-            syslog(LOG_WARNING, "[DHCPV4_RELAY] Invalid UDP packet from interface  %s\n", intf.c_str());
+            SWSS_LOG_WARN("[DHCPV4_RELAY] Invalid UDP packet from interface  %s", intf.c_str());
             if (!vlan_str.empty()) {
                 dhcp_cntr_table.increment_counter(vlan_str, "RX", DHCPv4_MESSAGE_TYPE_MALFORMED);
             }
@@ -1060,8 +1055,8 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
         /* Validate UDP checksum is correct */
         auto udp_checksum = udp_layer->calculateChecksum(false);
         if (htobe16(udp_checksum) != udp_layer->getUdpHeader()->headerChecksum) {
-            syslog(LOG_WARNING, "[DHCPV4_RELAY] UDP checksum validation is failing "
-                        " packet is from interface %s\n", intf.c_str());
+            SWSS_LOG_WARN("[DHCPV4_RELAY] UDP checksum validation is failing "
+                        " packet is from interface %s", intf.c_str());
             if (!vlan_str.empty()) {
                 dhcp_cntr_table.increment_counter(vlan_str, "RX", DHCPv4_MESSAGE_TYPE_MALFORMED);
             }
@@ -1070,7 +1065,7 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
 
         pcpp::DhcpLayer *dhcp_pkt = raw_pkt.getLayerOfType<pcpp::DhcpLayer>();
         if (dhcp_pkt == nullptr) {
-            syslog(LOG_WARNING, "[DHCPV4_RELAY] Invalid DHCP packet from interface  %s\n", intf.c_str());
+            SWSS_LOG_WARN("[DHCPV4_RELAY] Invalid DHCP packet from interface  %s", intf.c_str());
             if (!vlan_str.empty()) {
                 dhcp_cntr_table.increment_counter(vlan_str, "RX", DHCPv4_MESSAGE_TYPE_MALFORMED);
             }
@@ -1084,7 +1079,7 @@ void pkt_in_callback(evutil_socket_t fd, short event, void *arg) {
 
             auto config_itr = vlans->find(vlan_str);
             if (config_itr == vlans->end()) {
-                syslog(LOG_INFO, "[DHCPV4_RELAY] Relay config not found for %s (interface %s, vlan_id %d)\n",
+                SWSS_LOG_INFO("[DHCPV4_RELAY] Relay config not found for %s (interface %s, vlan_id %d)",
                        vlan_str.c_str(), intf.c_str(), vlan_id);
                 dhcp_cntr_table.increment_counter(vlan_str, "RX", DHCPv4_MESSAGE_TYPE_DROP);
                 continue;
@@ -1115,13 +1110,13 @@ int signal_init() {
     do {
         ev_sigint = evsignal_new(base, SIGINT, signal_callback, base);
         if (ev_sigint == NULL) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Could not create SIGINT libevent signal\n");
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Could not create SIGINT libevent signal");
             break;
         }
 
         ev_sigterm = evsignal_new(base, SIGTERM, signal_callback, base);
         if (ev_sigterm == NULL) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Could not create SIGTERM libevent signal\n");
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Could not create SIGTERM libevent signal");
             break;
         }
         rv = 0;
@@ -1138,17 +1133,17 @@ int signal_start() {
     int rv = -1;
     do {
         if (evsignal_add(ev_sigint, NULL) != 0) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Could not add SIGINT libevent signal\n");
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Could not add SIGINT libevent signal");
             break;
         }
 
         if (evsignal_add(ev_sigterm, NULL) != 0) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Could not add SIGTERM libevent signal\n");
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Could not add SIGTERM libevent signal");
             break;
         }
 
         if (event_base_dispatch(base) != 0) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Could not start libevent dispatching loop\n");
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Could not start libevent dispatching loop");
         }
 
         rv = 0;
@@ -1169,7 +1164,7 @@ int signal_start() {
  * @return none
  */
 void signal_callback(evutil_socket_t fd, short event, void *arg) {
-    syslog(LOG_ALERT, "[DHCPV4_RELAY] Received signal: '%s'\n", strsignal(fd));
+    SWSS_LOG_NOTICE("[DHCPV4_RELAY] Received signal: '%s'", strsignal(fd));
     if ((fd == SIGTERM) || (fd == SIGINT)) {
         dhcp4relay_stop();
     }
@@ -1205,7 +1200,7 @@ int handle_server_sock(relay_config &vlan_config, std::string new_vrf)
         vrf_sock_map[new_vrf].ref_count++;
     } else {
         if (prepare_vrf_sockets(vlan_config) == -1) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to create vrf listen socket");
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to create vrf listen socket");
             return -1;
         }
     }
@@ -1251,7 +1246,7 @@ static void apply_config_event(const event_config &received_event,
 	   (received_event.type == DHCPv4_SERVER_RELAY_CONFIG_UPDATE))	{
             relay_config *relay_msg = static_cast<relay_config *>(received_event.msg);
             if (relay_msg) {
-                syslog(LOG_INFO, "[DHCPV4_RELAY] Processing config update: VLAN %s", relay_msg->vlan.c_str());
+                SWSS_LOG_INFO("[DHCPV4_RELAY] Processing config update: VLAN %s", relay_msg->vlan.c_str());
 
                 if (relay_msg->is_add) {
                     if (vlans->find(relay_msg->vlan) == vlans->end()) {
@@ -1264,7 +1259,7 @@ static void apply_config_event(const event_config &received_event,
                            when VLAN_INTERFACE_UPDATE creates the socket.
                            relay_msg is freed at the end of this block */
                         if (prepare_vlan_sockets((*vlans)[relay_msg->vlan]) == -1) {
-                            syslog(LOG_NOTICE, "[DHCPV4_RELAY] VLAN socket not ready for %s, will create when IPv4 is assigned\n",
+                            SWSS_LOG_NOTICE("[DHCPV4_RELAY] VLAN socket not ready for %s, will create when IPv4 is assigned",
                                    relay_msg->vlan.c_str());
                         }
                         /* Intially filling the vlan interface IP address. */
@@ -1310,10 +1305,10 @@ static void apply_config_event(const event_config &received_event,
                             }
                         }
                         vlans->erase(relay_msg->vlan);
-                        syslog(LOG_INFO, "[DHCPV4_RELAY] Deleted VLAN %s from configuration", relay_msg->vlan.c_str());
+                        SWSS_LOG_INFO("[DHCPV4_RELAY] Deleted VLAN %s from configuration", relay_msg->vlan.c_str());
                         update_vlan_mapping(relay_msg->vlan, false);
                     } else {
-                        syslog(LOG_WARNING, "[DHCPV4_RELAY] Attempted to delete non-existent VLAN %s", relay_msg->vlan.c_str());
+                        SWSS_LOG_WARN("[DHCPV4_RELAY] Attempted to delete non-existent VLAN %s", relay_msg->vlan.c_str());
                     }
                 }
                 delete relay_msg;
@@ -1322,12 +1317,12 @@ static void apply_config_event(const event_config &received_event,
             relay_config *relay_msg = static_cast<relay_config *>(received_event.msg);
             if (relay_msg) {
                 if (vlans->find(relay_msg->vlan) == vlans->end()) {
-                    syslog(LOG_WARNING, "[DHCPV4_RELAY] Ignoring INTERFACE_UPDATE for unknown VLAN %s\n",
+                    SWSS_LOG_WARN("[DHCPV4_RELAY] Ignoring INTERFACE_UPDATE for unknown VLAN %s",
                                   relay_msg->vlan.c_str());
                     delete relay_msg;
                     return;
                 }
-                syslog(LOG_INFO, "[DHCPV4_RELAY] Updating source interface for VLAN %s", relay_msg->vlan.c_str());
+                SWSS_LOG_INFO("[DHCPV4_RELAY] Updating source interface for VLAN %s", relay_msg->vlan.c_str());
                 if (relay_msg->is_add) {
                     vlans->at(relay_msg->vlan).src_intf_sel_addr = relay_msg->src_intf_sel_addr;
                 } else {
@@ -1338,7 +1333,7 @@ static void apply_config_event(const event_config &received_event,
         } else if (received_event.type == DHCPv4_RELAY_VLAN_MEMBER_UPDATE) {
                vlan_member_config *msg = static_cast<vlan_member_config *>(received_event.msg);
                if (msg) {
-                   syslog(LOG_INFO, "[DHCPV4_RELAY] Updating vlan member for VLAN %s", msg->vlan.c_str());
+                   SWSS_LOG_INFO("[DHCPV4_RELAY] Updating vlan member for VLAN %s", msg->vlan.c_str());
                    if (vlans->find(msg->vlan) == vlans->end()) {
                        delete msg;
                        return;
@@ -1353,7 +1348,7 @@ static void apply_config_event(const event_config &received_event,
                    /* Do not early-return on socket failure: msg is freed
                       immediately below; no code follows between here and delete. */
                    if (prepare_vlan_sockets((*vlans)[msg->vlan]) == -1) {
-                       syslog(LOG_NOTICE, "[DHCPV4_RELAY] VLAN socket not ready for %s, will create when IPv4 is assigned\n",
+                       SWSS_LOG_NOTICE("[DHCPV4_RELAY] VLAN socket not ready for %s, will create when IPv4 is assigned",
                               msg->vlan.c_str());
                    }
                    prepare_relay_interface_config((*vlans)[msg->vlan]);
@@ -1362,7 +1357,7 @@ static void apply_config_event(const event_config &received_event,
 	} else if (received_event.type == DHCPv4_RELAY_VLAN_INTERFACE_UPDATE) {
                vlan_interface_config *msg = static_cast<vlan_interface_config *>(received_event.msg);
                if (msg) {
-                   syslog(LOG_INFO, "[DHCPV4_RELAY] Updating vlan interface event for VLAN %s", msg->vlan.c_str());
+                   SWSS_LOG_INFO("[DHCPV4_RELAY] Updating vlan interface event for VLAN %s", msg->vlan.c_str());
                    if (vlans->find(msg->vlan) == vlans->end()) {
                        delete msg;
                        return;
@@ -1376,7 +1371,7 @@ static void apply_config_event(const event_config &received_event,
                           (*vlans)[msg->vlan].client_sock = 0;
                       }
                       if (prepare_vlan_sockets((*vlans)[msg->vlan]) == -1) {
-                          syslog(LOG_NOTICE, "[DHCPV4_RELAY] VLAN socket not ready for %s, will retry on next event\n",
+                          SWSS_LOG_NOTICE("[DHCPV4_RELAY] VLAN socket not ready for %s, will retry on next event",
                                           msg->vlan.c_str());
                       }
                       prepare_relay_interface_config((*vlans)[msg->vlan]);
@@ -1401,10 +1396,10 @@ static void apply_config_event(const event_config &received_event,
                }
         } else if ((received_event.type == DHCPv4_SERVER_FEATURE_UPDATE) ||
                    (received_event.type == DHCPv4_SERVER_IP_DELETE)) {
-                   syslog(LOG_INFO, "[DHCPV4_RELAY]  dhcp_server feature table update or server ip delete event received");
+                   SWSS_LOG_INFO("[DHCPV4_RELAY]  dhcp_server feature table update or server ip delete event received");
                    delete_all_relay_configs(vlans);
         } else if (received_event.type == DHCPv4_SERVER_IP_UPDATE) {
-                syslog(LOG_INFO, "[DHCPV4_RELAY]  dhcp_server IP update in state DB event received");
+                SWSS_LOG_INFO("[DHCPV4_RELAY]  dhcp_server IP update in state DB event received");
                 for (auto it = vlans->begin(); it != vlans->end(); ++it) {
                      relay_config &config = it->second;
                      config.servers.clear();
@@ -1416,11 +1411,9 @@ static void apply_config_event(const event_config &received_event,
             relay_config *relay_msg = static_cast<relay_config *>(received_event.msg);
             if (relay_msg) {
                 if (relay_msg->is_add) {
-                    syslog(LOG_INFO,
-                       "[DHCPV4_RELAY][DualTor] Adding link-selection and source-interface as Loopback0 for existing vlans");
+                    SWSS_LOG_INFO("[DHCPV4_RELAY][DualTor] Adding link-selection and source-interface as Loopback0 for existing vlans");
                 } else {
-                    syslog(LOG_INFO,
-                       "[DHCPV4_RELAY][DualTor] Deleting/Restoring link-selection and source-interface configs for existing vlans");
+                    SWSS_LOG_INFO("[DHCPV4_RELAY][DualTor] Deleting/Restoring link-selection and source-interface configs for existing vlans");
                 }
 
                 for (auto& vlan : *vlans) {
@@ -1458,7 +1451,7 @@ static void apply_config_event(const event_config &received_event,
 	} else if (received_event.type == DHCPv4_RELAY_PORT_UPDATE) {
                port_config *port_msg = static_cast<port_config *>(received_event.msg);
                if (port_msg) {
-                   syslog(LOG_INFO, "[DHCPV4_RELAY] Updating interface %s event", port_msg->phy_interface.c_str());
+                   SWSS_LOG_INFO("[DHCPV4_RELAY] Updating interface %s event", port_msg->phy_interface.c_str());
                     if (port_msg->is_add) {
                        if (std::find(interface_list.begin(), interface_list.end(), port_msg->phy_interface) == interface_list.end()) {
                            interface_list.push_back(port_msg->phy_interface);
@@ -1489,7 +1482,7 @@ void config_event_callback(evutil_socket_t fd, short event, void *arg) {
         }
         apply_config_event(received_event, vlans);
     } else {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to read config update: expected %lu bytes, got %zd bytes", sizeof(received_event), bytes_read);
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to read config update: expected %lu bytes, got %zd bytes", sizeof(received_event), bytes_read);
     }
 }
 
@@ -1515,7 +1508,7 @@ void config_event_callback(evutil_socket_t fd, short event, void *arg) {
 void loop_relay(std::unordered_map<std::string, relay_config> &vlans) {
     base = event_base_new();
     if (base == NULL) {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] libevent: Failed to create event base\n");
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] libevent: Failed to create event base");
         exit(EXIT_FAILURE);
     }
 
@@ -1531,7 +1524,7 @@ void loop_relay(std::unordered_map<std::string, relay_config> &vlans) {
 
     // Create the pipe for inter-thread communication
     if (pipe(config_pipe) == -1) {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to create config update pipe");
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to create config update pipe");
         exit(EXIT_FAILURE);
     }
 
@@ -1543,7 +1536,7 @@ void loop_relay(std::unordered_map<std::string, relay_config> &vlans) {
     struct event *config_event = event_new(base, config_pipe[0], EV_READ | EV_PERSIST,
                                            config_event_callback, reinterpret_cast<void *>(&vlans));
     if (!config_event) {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to create event for config pipe");
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to create event for config pipe");
         exit(EXIT_FAILURE);
     }
 
@@ -1558,12 +1551,12 @@ void loop_relay(std::unordered_map<std::string, relay_config> &vlans) {
         pkt_event = event_new(base, filter, EV_READ | EV_PERSIST, pkt_in_callback,
                               reinterpret_cast<void *>(&vlans));
         if (pkt_event == NULL) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] libevent: Failed to create client listen event\n");
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] libevent: Failed to create client listen event");
             exit(EXIT_FAILURE);
         }
-        syslog(LOG_INFO, "[DHCPV4_RELAY] libevent: Created client listen socket event (deferred)\n");
+        SWSS_LOG_INFO("[DHCPV4_RELAY] libevent: Created client listen socket event (deferred)");
     } else {
-        syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to create client listen socket");
+        SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to create client listen socket");
         exit(EXIT_FAILURE);
     }
 
@@ -1595,9 +1588,9 @@ void loop_relay(std::unordered_map<std::string, relay_config> &vlans) {
     // important post-drain, but pipe-first matches the natural
     // 'config-before-packets' intent.
     event_add(config_event, NULL);
-    syslog(LOG_INFO, "[DHCPV4_RELAY] Added event listener for config updates");
+    SWSS_LOG_INFO("[DHCPV4_RELAY] Added event listener for config updates");
     event_add(pkt_event, NULL);
-    syslog(LOG_INFO, "[DHCPV4_RELAY] libevent: Add client listen socket event\n");
+    SWSS_LOG_INFO("[DHCPV4_RELAY] libevent: Add client listen socket event");
 
     if (signal_init() == 0 && signal_start() == 0) {
         shutdown_relay();

--- a/dhcp4relay/src/dhcp4relay.h
+++ b/dhcp4relay/src/dhcp4relay.h
@@ -9,7 +9,7 @@
 #include <netinet/if_ether.h>
 #include <netinet/ip.h>
 #include <netinet/udp.h>
-#include <syslog.h>
+#include "logger.h"
 
 #include <map>
 #include <string>

--- a/dhcp4relay/src/dhcp4relay_mgr.cpp
+++ b/dhcp4relay/src/dhcp4relay_mgr.cpp
@@ -97,13 +97,11 @@ void DHCPMgr::handle_swss_notification() {
         std::deque<swss::KeyOpFieldsValuesTuple> initial_entries;
         config_db_relaymgr_table_ptr->pops(initial_entries);
         if (!initial_entries.empty()) {
-            syslog(LOG_INFO,
-                   "[DHCPV4_RELAY] Loading initial DHCPV4_RELAY snapshot: %zu entries",
+            SWSS_LOG_INFO("[DHCPV4_RELAY] Loading initial DHCPV4_RELAY snapshot: %zu entries",
                    initial_entries.size());
             process_relay_notification(initial_entries);
         } else {
-            syslog(LOG_INFO,
-                   "[DHCPV4_RELAY] No DHCPV4_RELAY entries present at startup");
+            SWSS_LOG_INFO("[DHCPV4_RELAY] No DHCPV4_RELAY entries present at startup");
         }
 
         event_config barrier_event{};
@@ -111,8 +109,7 @@ void DHCPMgr::handle_swss_notification() {
         barrier_event.msg = nullptr;
         if (write(config_pipe[1], &barrier_event, sizeof(barrier_event))
                 != static_cast<ssize_t>(sizeof(barrier_event))) {
-            syslog(LOG_ERR,
-                   "[DHCPV4_RELAY] Failed to write sync barrier to config pipe: %s; exiting to avoid startup hang",
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to write sync barrier to config pipe: %s; exiting to avoid startup hang",
                    strerror(errno));
             exit(EXIT_FAILURE);
         }
@@ -123,12 +120,12 @@ void DHCPMgr::handle_swss_notification() {
         int ret = swss_select.select(&selectable, DEFAULT_TIMEOUT_MSEC);
 
         if (ret == swss::Select::ERROR) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Error had been returned in select");
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Error had been returned in select");
             continue;
         } else if (ret == swss::Select::TIMEOUT) {
             continue;
         } else if (ret != swss::Select::OBJECT) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Unknown return value from Select: %d", ret);
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Unknown return value from Select: %d", ret);
             continue;
         }
 
@@ -220,7 +217,7 @@ void DHCPMgr::process_device_metadata_notification(std::deque<swss::KeyOpFieldsV
                 try {
                     m_config.deployment_id = static_cast<uint32_t>(std::stoul(v));
                 } catch (const std::exception &e) {
-                    syslog(LOG_WARNING, "[DHCPV4_RELAY] Invalid deployment_id value '%s': %s\n", v.c_str(), e.what());
+                    SWSS_LOG_WARN("[DHCPV4_RELAY] Invalid deployment_id value '%s': %s", v.c_str(), e.what());
                 }
             } else if (f == "subtype") {
                 subtype_found = true;
@@ -245,7 +242,7 @@ void DHCPMgr::process_device_metadata_notification(std::deque<swss::KeyOpFieldsV
                 if (ok) {
                     m_config.midplane_bridge = bridge_name;
                 } else {
-                    syslog(LOG_ERR, "Failed to read midplane bridge name\n");
+                    SWSS_LOG_ERROR("Failed to read midplane bridge name");
                 }
             } else if (m_config.is_SmartSwitch) {
                 m_config.is_SmartSwitch = false;
@@ -256,7 +253,7 @@ void DHCPMgr::process_device_metadata_notification(std::deque<swss::KeyOpFieldsV
                 try {
                     relay_msg = new relay_config();
                 } catch (const std::bad_alloc &e) {
-                    syslog(LOG_ERR, "[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
+                    SWSS_LOG_ERROR("[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
                     return;
                 }
 
@@ -271,7 +268,7 @@ void DHCPMgr::process_device_metadata_notification(std::deque<swss::KeyOpFieldsV
                 event.msg = static_cast<void *>(relay_msg);
                 // Write the pointer address to the pipe
                 if (write(config_pipe[1], &event, sizeof(event)) == -1) {
-                    syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to write to config update pipe: %s", strerror(errno));
+                    SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to write to config update pipe: %s", strerror(errno));
                     delete relay_msg;
                 }
 	    }
@@ -322,7 +319,7 @@ void DHCPMgr::process_interface_notification(std::deque<swss::KeyOpFieldsValuesT
                 try {
                     relay_msg = new relay_config();
                 } catch (const std::bad_alloc &e) {
-                    syslog(LOG_ERR, "[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
+                    SWSS_LOG_ERROR("[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
                     return;
                 }
 
@@ -330,7 +327,7 @@ void DHCPMgr::process_interface_notification(std::deque<swss::KeyOpFieldsValuesT
                 if (operation == "SET") {
                     relay_msg->is_add = true;
                     if (inet_pton(AF_INET, ip.c_str(), &relay_msg->src_intf_sel_addr.sin_addr) != 1) {
-                        syslog(LOG_ERR, "[DHCPV4_RELAY] Invalid IP address");
+                        SWSS_LOG_ERROR("[DHCPV4_RELAY] Invalid IP address");
                         delete relay_msg;
                         return;
                     }
@@ -345,7 +342,7 @@ void DHCPMgr::process_interface_notification(std::deque<swss::KeyOpFieldsValuesT
                 event.msg = static_cast<void *>(relay_msg);
                 // Write the pointer address to the pipe
                 if (write(config_pipe[1], &event, sizeof(event)) == -1) {
-                    syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to write to config update pipe: %s", strerror(errno));
+                    SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to write to config update pipe: %s", strerror(errno));
                     delete relay_msg;
                 }
             }
@@ -377,7 +374,7 @@ void DHCPMgr::process_relay_notification(std::deque<swss::KeyOpFieldsValuesTuple
         try {
             relay_msg = new relay_config();
         } catch (const std::bad_alloc &e) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
             return;
         }
 
@@ -411,11 +408,11 @@ void DHCPMgr::process_relay_notification(std::deque<swss::KeyOpFieldsValuesTuple
                     try {
                         relay_msg->max_hop_count = static_cast<uint8_t>(std::stoi(v));
                     } catch (const std::exception &e) {
-                        syslog(LOG_WARNING, "[DHCPV4_RELAY] Invalid max_hop_count value '%s' for VLAN %s: %s\n",
+                        SWSS_LOG_WARN("[DHCPV4_RELAY] Invalid max_hop_count value '%s' for VLAN %s: %s",
                                v.c_str(), vlan.c_str(), e.what());
                     }
                 }
-                syslog(LOG_DEBUG, "[DHCPV4_RELAY] key: %s, Operation: %s, f: %s, v: %s", vlan.c_str(), operation.c_str(), f.c_str(), v.c_str());
+                SWSS_LOG_DEBUG("[DHCPV4_RELAY] key: %s, Operation: %s, f: %s, v: %s", vlan.c_str(), operation.c_str(), f.c_str(), v.c_str());
             }
 
             // Updating vrf value with client VRF if server vrf is not configured.
@@ -434,18 +431,18 @@ void DHCPMgr::process_relay_notification(std::deque<swss::KeyOpFieldsValuesTuple
             // Update the vlan cache entry
             vlans_copy[relay_msg->vlan] = *relay_msg;
         } else if (operation == "DEL") {
-            syslog(LOG_INFO, "[DHCPV4_RELAY] Received DELETE operation for VLAN %s", vlan.c_str());
+            SWSS_LOG_INFO("[DHCPV4_RELAY] Received DELETE operation for VLAN %s", vlan.c_str());
             relay_msg->is_add = false;
             // Remove the vlan cache entry
             vlans_copy.erase(relay_msg->vlan);
         }
 
         if (relay_msg->servers.empty() && operation != "DEL") {
-            syslog(LOG_WARNING, "[DHCPV4_RELAY] No servers found for VLAN %s, skipping configuration.", vlan.c_str());
+            SWSS_LOG_WARN("[DHCPV4_RELAY] No servers found for VLAN %s, skipping configuration.", vlan.c_str());
             delete relay_msg;
             continue;
         }
-        syslog(LOG_INFO, "[DHCPV4_RELAY] %s %s relay config\n", operation.c_str(), vlan.c_str());
+        SWSS_LOG_INFO("[DHCPV4_RELAY] %s %s relay config", operation.c_str(), vlan.c_str());
 
         event_config event;
         event.type = DHCPv4_RELAY_CONFIG_UPDATE;
@@ -453,7 +450,7 @@ void DHCPMgr::process_relay_notification(std::deque<swss::KeyOpFieldsValuesTuple
 
         // Write the pointer address to the pipe
         if (write(config_pipe[1], &event, sizeof(event)) == -1) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to write to config update pipe: %s", strerror(errno));
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to write to config update pipe: %s", strerror(errno));
             delete relay_msg;
         }
     }
@@ -498,7 +495,7 @@ void DHCPMgr::process_feature_notification(std::deque<swss::KeyOpFieldsValuesTup
             event.type = DHCPv4_SERVER_FEATURE_UPDATE;
 
             if (write(config_pipe[1], &event, sizeof(event)) == -1) {
-                syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to send delete event for dhcp_server feature update");
+                SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to send delete event for dhcp_server feature update");
 		return;
             }
             vlans_copy.clear();
@@ -517,7 +514,7 @@ void DHCPMgr::process_feature_notification(std::deque<swss::KeyOpFieldsValuesTup
             select.addSelectable(config_db_dhcp_server_ipv4_ptr.get());
             select.addSelectable(state_db_dhcp_server_ipv4_ip_ptr.get());
         } else if (state == "disabled" && feature_dhcp_server_enabled) {
-            syslog(LOG_INFO, "[DHCPV4_RELAY] Disabling DHCP server auto-config mode and cleaning up.");
+            SWSS_LOG_INFO("[DHCPV4_RELAY] Disabling DHCP server auto-config mode and cleaning up.");
             feature_dhcp_server_enabled = false;
             global_dhcp_server_ip.clear();
 	    vlans_copy.clear();
@@ -526,7 +523,7 @@ void DHCPMgr::process_feature_notification(std::deque<swss::KeyOpFieldsValuesTup
             event.type = DHCPv4_SERVER_FEATURE_UPDATE;
 
             if (write(config_pipe[1], &event, sizeof(event)) == -1) {
-                syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to send delete event for dhcp_server feature update");
+                SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to send delete event for dhcp_server feature update");
 		return;
             }
 
@@ -577,7 +574,7 @@ void DHCPMgr::process_dhcp_server_ipv4_ip_notification(std::deque<swss::KeyOpFie
                   }
             }
 	    if (server_ip.empty()) {
-		  syslog(LOG_ERR, "[DHCPV4_RELAY] dhcp_server IP is not present in state DB");
+		  SWSS_LOG_ERROR("[DHCPV4_RELAY] dhcp_server IP is not present in state DB");
 		  return;
             }
 	    //modification case
@@ -586,7 +583,7 @@ void DHCPMgr::process_dhcp_server_ipv4_ip_notification(std::deque<swss::KeyOpFie
                 event.type = DHCPv4_SERVER_IP_UPDATE;
 
 		if (write(config_pipe[1], &event, sizeof(event)) == -1) {
-                    syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to send delete event for dhcp_server IP update");
+                    SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to send delete event for dhcp_server IP update");
 		    return;
                 }
 		is_modify = true;
@@ -594,7 +591,7 @@ void DHCPMgr::process_dhcp_server_ipv4_ip_notification(std::deque<swss::KeyOpFie
 	    global_dhcp_server_ip = server_ip;
 	    //Since the server IP see newly added, restart the listener for the dhcp_server config.
 	    if (!is_modify) {
-	       syslog(LOG_INFO, "[DHCPV4_RELAY] Restarting the dhcp_server listener");
+	       SWSS_LOG_INFO("[DHCPV4_RELAY] Restarting the dhcp_server listener");
                if (config_db_dhcp_server_ipv4_ptr) {
                    select.removeSelectable(config_db_dhcp_server_ipv4_ptr.get());
                }
@@ -607,7 +604,7 @@ void DHCPMgr::process_dhcp_server_ipv4_ip_notification(std::deque<swss::KeyOpFie
             event.type = DHCPv4_SERVER_IP_DELETE;
 
             if (write(config_pipe[1], &event, sizeof(event)) == -1) {
-                syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to send delete event for dhcp_server IP delete");
+                SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to send delete event for dhcp_server IP delete");
 		return;
             }
 	    global_dhcp_server_ip.clear();
@@ -623,7 +620,7 @@ void DHCPMgr::process_vlan_member_notification(std::deque<swss::KeyOpFieldsValue
 
          size_t pos = key.find('|');
          if (pos == std::string::npos) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Invalid string format");
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Invalid string format");
             return;
          }
 
@@ -639,7 +636,7 @@ void DHCPMgr::process_vlan_member_notification(std::deque<swss::KeyOpFieldsValue
         try {
             msg = new vlan_member_config();
         } catch (const std::bad_alloc &e) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
             return;
         }
 
@@ -657,7 +654,7 @@ void DHCPMgr::process_vlan_member_notification(std::deque<swss::KeyOpFieldsValue
         event.msg = static_cast<void *>(msg);
 
         if (write(config_pipe[1], &event, sizeof(event)) == -1) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to send vlan member update for vlan %s", vlan.c_str());
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to send vlan member update for vlan %s", vlan.c_str());
             delete msg;
         }
      }
@@ -696,7 +693,7 @@ void DHCPMgr::process_vlan_interface_notification(std::deque<swss::KeyOpFieldsVa
         try {
             msg = new vlan_interface_config();
         } catch (const std::bad_alloc &e) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
             return;
         }
         msg->vlan = vlan;
@@ -707,7 +704,7 @@ void DHCPMgr::process_vlan_interface_notification(std::deque<swss::KeyOpFieldsVa
         event.msg = static_cast<void *>(msg);
 
         if (write(config_pipe[1], &event, sizeof(event)) == -1) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to send vlan interface update for vlan %s", vlan.c_str());
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to send vlan interface update for vlan %s", vlan.c_str());
             delete msg;
         }
 
@@ -742,7 +739,7 @@ void DHCPMgr::process_dhcp_server_ipv4_notification(std::deque<swss::KeyOpFields
         try {
             relay_msg = new relay_config();
         } catch (const std::bad_alloc &e) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
             return;
         }
 
@@ -766,9 +763,9 @@ void DHCPMgr::process_dhcp_server_ipv4_notification(std::deque<swss::KeyOpFields
                   ip_tbl.hget("eth0", "ip", ip);
                   if (!ip.empty()) {
                      global_dhcp_server_ip = ip;
-                     syslog(LOG_INFO, "[DHCPV4_RELAY] Fetched DHCPv4 server IP from STATE_DB: %s", ip.c_str());
+                     SWSS_LOG_INFO("[DHCPV4_RELAY] Fetched DHCPv4 server IP from STATE_DB: %s", ip.c_str());
                   } else {
-                     syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to get DHCPv4 server IP from STATE_DB");
+                     SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to get DHCPv4 server IP from STATE_DB");
                      delete relay_msg;
                      continue;
                   }
@@ -804,7 +801,7 @@ void DHCPMgr::process_dhcp_server_ipv4_notification(std::deque<swss::KeyOpFields
         event.msg = static_cast<void *>(relay_msg);
 
         if (write(config_pipe[1], &event, sizeof(event)) == -1) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to send vlan table update for VLAN %s", vlan.c_str());
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to send vlan table update for VLAN %s", vlan.c_str());
             delete relay_msg;
         }
     }
@@ -833,7 +830,7 @@ void DHCPMgr::process_vlan_notification(std::deque<swss::KeyOpFieldsValuesTuple>
         try {
             relay_msg = new relay_config();
         } catch (const std::bad_alloc &e) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
             return;
         }
 
@@ -855,7 +852,7 @@ void DHCPMgr::process_vlan_notification(std::deque<swss::KeyOpFieldsValuesTuple>
         event.msg = static_cast<void *>(relay_msg);
 
         if (write(config_pipe[1], &event, sizeof(event)) == -1) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to send vlan update event for vlan %s", vlan.c_str());
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to send vlan update event for vlan %s", vlan.c_str());
             delete relay_msg;
         }
     }
@@ -870,7 +867,7 @@ void DHCPMgr::process_port_notification(std::deque<swss::KeyOpFieldsValuesTuple>
         try {
             port_msg = new port_config();
         } catch (const std::bad_alloc &e) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
             return;
         }
 
@@ -895,7 +892,7 @@ void DHCPMgr::process_port_notification(std::deque<swss::KeyOpFieldsValuesTuple>
         event.msg = static_cast<void *>(port_msg);
 
         if (write(config_pipe[1], &event, sizeof(event)) == -1) {
-            syslog(LOG_ERR, "[DHCPV4_RELAY] Failed to send port table update for interface %s", interface.c_str());
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to send port table update for interface %s", interface.c_str());
             delete port_msg;
         }
      }

--- a/dhcp4relay/src/dhcp4relay_stats.cpp
+++ b/dhcp4relay/src/dhcp4relay_stats.cpp
@@ -76,7 +76,7 @@ void update_interface_counters_in_db(
         try {
             counter_map[fvField(field)] = std::stoi(fvValue(field));
         } catch (const std::exception &e) {
-            syslog(LOG_WARNING, "[DHCPV4_RELAY] update_interface_counters_in_db: invalid counter value '%s' for field '%s': %s\n",
+            SWSS_LOG_WARN("[DHCPV4_RELAY] update_interface_counters_in_db: invalid counter value '%s' for field '%s': %s",
                    fvValue(field).c_str(), fvField(field).c_str(), e.what());
         }
     }
@@ -140,7 +140,7 @@ void DHCPCounter_table::db_update_loop() {
                 }
             }
         }
-        syslog(LOG_INFO, "DHCPV4_RELAY: DHCPCounter_table::db_update_loop() : Data Updated to DB \n");
+        SWSS_LOG_INFO("DHCPV4_RELAY: DHCPCounter_table::db_update_loop() : Data Updated to DB ");
     }
 }
 
@@ -205,7 +205,7 @@ void DHCPCounter_table::increment_counter(const std::string& interface,
                                         int msg_type) {
     auto type_itr = counter_map.find(msg_type);
     if (type_itr == counter_map.end()) {
-        syslog(LOG_WARNING, "[DHCPV4_RELAY] increment_counter: unknown msg_type %d, counting as Unknown\n", msg_type);
+        SWSS_LOG_WARN("[DHCPV4_RELAY] increment_counter: unknown msg_type %d, counting as Unknown", msg_type);
         type_itr = counter_map.find(DHCPv4_MESSAGE_TYPE_UNKNOWN);
         if (type_itr == counter_map.end()) {
             return;

--- a/dhcp4relay/src/main.cpp
+++ b/dhcp4relay/src/main.cpp
@@ -1,5 +1,5 @@
 #include <stdlib.h>
-#include <syslog.h>
+#include "logger.h"
 
 #include <unordered_map>
 
@@ -9,11 +9,12 @@ bool dual_tor_sock = false;
 char loopback[IF_NAMESIZE] = "Loopback0";
 
 int main(int argc, char *argv[]) {
+    swss::Logger::linkToDbNative("dhcp4relay");
     try {
         std::unordered_map<std::string, relay_config> vlans;
         loop_relay(vlans);
     } catch (std::exception &e) {
-        syslog(LOG_ERR, "An exception occurred.\n");
+        SWSS_LOG_ERROR("An exception occurred.");
         return 1;
     }
     return 0;


### PR DESCRIPTION
dhcp4relay used raw syslog() calls throughout, which meant every log message regardless of level was unconditionally written to syslog with no way to suppress verbose output at runtime. Under sustained DHCP traffic the relay generates several hundred log lines per second, saturating rsyslog rate limits and causing syslog to rotate every ~14 minutes, burying real errors.

This commit integrates swss::Logger so that log levels can be controlled at runtime via swssloglevel without restarting the daemon.

Changes
-------
- main.cpp: add swss::Logger::linkToDbNative("dhcp4relay") to register with LOGLEVEL_DB at startup (default level: NOTICE).
- dhcp4relay.h: replace #include <syslog.h> with #include "logger.h". All .cpp files that include dhcp4relay.h (directly or transitively via dhcp4relay_mgr.h / dhcp4relay_stats.h) pick up logger.h through the existing include chain; no per-file change needed.
- dhcp4_sender.cpp: replace #include <syslog.h> with #include "logger.h".
- dhcp4relay.cpp, dhcp4relay_mgr.cpp, dhcp4relay_stats.cpp, dhcp4_sender.cpp, main.cpp: replace all 131 syslog() calls with the equivalent SWSS_LOG_* macros:
    LOG_ERR     -> SWSS_LOG_ERROR
    LOG_WARNING -> SWSS_LOG_WARN
    LOG_NOTICE  -> SWSS_LOG_NOTICE
    LOG_INFO    -> SWSS_LOG_INFO
    LOG_DEBUG   -> SWSS_LOG_DEBUG
    LOG_ALERT   -> SWSS_LOG_NOTICE  (signal_callback: receiving SIGTERM
                                     is normal operational behavior)
- Remove trailing \n from all format strings; SWSS_LOG adds its own.

Log level control after this change
------------------------------------
  swssloglevel -c dhcp4relay -l NOTICE   # production default
  swssloglevel -c dhcp4relay -l INFO     # verbose operation
  swssloglevel -c dhcp4relay -l DEBUG    # full per-packet tracing

No functional change to relay behavior.