### PR TITLE
dhcp4relay drops packets on first VLANs in large batch

### DIFF
--- a/dhcp4relay/src/dhcp4relay_mgr.cpp
+++ b/dhcp4relay/src/dhcp4relay_mgr.cpp
@@ -7,6 +7,12 @@ constexpr auto DEFAULT_TIMEOUT_MSEC = 1000;
 
 std::unordered_map<std::string, relay_config> vlans_copy;
 
+/* In-process cache of <intf_name, sockaddr_in> populated from *INTERFACE
+   table events. Lets us replay an INTERFACE_UPDATE for a vlan whose
+   source_interface IP was already observed before the DHCPV4_RELAY
+   config for that vlan landed in vlans_copy. */
+std::unordered_map<std::string, sockaddr_in> intf_to_addr_cache;
+
 #ifdef UNIT_TEST
 using namespace swss;
 #endif
@@ -104,6 +110,26 @@ void DHCPMgr::handle_swss_notification() {
             SWSS_LOG_INFO("[DHCPV4_RELAY] No DHCPV4_RELAY entries present at startup");
         }
 
+        /* Drain the *INTERFACE SubscriberStateTable buffers (already seeded
+           with the CONFIG_DB snapshot at construction time) before the
+           barrier. process_interface_notification populates
+           intf_to_addr_cache and dispatches INTERFACE_UPDATE for vlans
+           registered above so the main thread applies the correct
+           src_intf_sel_addr as part of the initial sync. */
+        std::deque<swss::KeyOpFieldsValuesTuple> intf_entries;
+        config_db_loopback_table.pops(intf_entries);
+        if (!intf_entries.empty()) {
+            process_interface_notification(intf_entries);
+        }
+        config_db_interface_table.pops(intf_entries);
+        if (!intf_entries.empty()) {
+            process_interface_notification(intf_entries);
+        }
+        config_db_portchannel_table.pops(intf_entries);
+        if (!intf_entries.empty()) {
+            process_interface_notification(intf_entries);
+        }
+
         event_config barrier_event{};
         barrier_event.type = DHCPv4_RELAY_SYNC_BARRIER;
         barrier_event.msg = nullptr;
@@ -133,6 +159,16 @@ void DHCPMgr::handle_swss_notification() {
             if (config_db_relaymgr_table_ptr && selectable == config_db_relaymgr_table_ptr.get()) {
                 config_db_relaymgr_table_ptr->pops(entries);
                 process_relay_notification(entries);
+                /* Runtime: a DHCPV4_RELAY batch may register a vlan whose
+                   source_interface IP was cached by an earlier *INTERFACE
+                   event but never dispatched (vlans_copy didn't yet
+                   contain the vlan at that point). Replay from the
+                   in-process cache so the main thread overwrites any
+                   src_intf_sel_addr=0 set by prepare_relay_interface_config()
+                   before relayed packets arrive. */
+                if (!entries.empty()) {
+                    dispatch_source_intf_from_cache();
+                }
             } else if (selectable == static_cast<swss::Selectable *>(&config_db_interface_table)) {
                 config_db_interface_table.pops(entries);
                 process_interface_notification(entries);
@@ -312,6 +348,23 @@ void DHCPMgr::process_interface_notification(std::deque<swss::KeyOpFieldsValuesT
             continue;
         }
 
+        /* Update intf_to_addr_cache (IPv4 only). Captures the IP for
+           any vlan whose source_interface gets configured later, so a
+           DHCPV4_RELAY batch arriving after the *INTERFACE event can
+           still recover the correct src_intf_sel_addr without a Redis
+           hit. */
+        if (ip.find(':') == std::string::npos) {
+            if (operation == "SET") {
+                sockaddr_in tmp{};
+                if (inet_pton(AF_INET, ip.c_str(), &tmp.sin_addr) == 1) {
+                    tmp.sin_family = AF_INET;
+                    intf_to_addr_cache[intf_name] = tmp;
+                }
+            } else if (operation == "DEL") {
+                intf_to_addr_cache.erase(intf_name);
+            }
+        }
+
         // Check the source interface is configured in dhcp relay config.
         for (auto &vlan : vlans_copy) {
             if (vlan.second.source_interface == intf_name) {
@@ -451,6 +504,56 @@ void DHCPMgr::process_relay_notification(std::deque<swss::KeyOpFieldsValuesTuple
         // Write the pointer address to the pipe
         if (write(config_pipe[1], &event, sizeof(event)) == -1) {
             SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to write to config update pipe: %s", strerror(errno));
+            delete relay_msg;
+        }
+    }
+}
+
+/**
+ * @brief Dispatch INTERFACE_UPDATE events from intf_to_addr_cache.
+ *
+ * For every vlan in vlans_copy with a configured source_interface that has
+ * an entry in intf_to_addr_cache, push a DHCPv4_RELAY_INTERFACE_UPDATE
+ * event down config_pipe. Pure in-process: no Redis access. Invoked after
+ * a runtime DHCPV4_RELAY batch to recover an IP that *INTERFACE
+ * notifications recorded into the cache before the matching vlan was in
+ * vlans_copy. Idempotent against the existing INTERFACE_UPDATE flow.
+ */
+void DHCPMgr::dispatch_source_intf_from_cache() {
+    if (vlans_copy.empty() || intf_to_addr_cache.empty()) {
+        return;
+    }
+
+    for (auto &vlan_entry : vlans_copy) {
+        const std::string &intf = vlan_entry.second.source_interface;
+        if (intf.empty()) {
+            continue;
+        }
+
+        auto it = intf_to_addr_cache.find(intf);
+        if (it == intf_to_addr_cache.end()) {
+            continue;
+        }
+
+        relay_config *relay_msg = nullptr;
+        try {
+            relay_msg = new relay_config();
+        } catch (const std::bad_alloc &e) {
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Memory allocation failed: %s", e.what());
+            return;
+        }
+
+        relay_msg->vlan = vlan_entry.second.vlan;
+        relay_msg->is_add = true;
+        relay_msg->src_intf_sel_addr = it->second;
+
+        event_config event;
+        event.type = DHCPv4_RELAY_INTERFACE_UPDATE;
+        event.msg = static_cast<void *>(relay_msg);
+
+        if (write(config_pipe[1], &event, sizeof(event)) == -1) {
+            SWSS_LOG_ERROR("[DHCPV4_RELAY] Failed to write to config update pipe: %s",
+                           strerror(errno));
             delete relay_msg;
         }
     }

--- a/dhcp4relay/src/dhcp4relay_mgr.cpp
+++ b/dhcp4relay/src/dhcp4relay_mgr.cpp
@@ -7,11 +7,8 @@ constexpr auto DEFAULT_TIMEOUT_MSEC = 1000;
 
 std::unordered_map<std::string, relay_config> vlans_copy;
 
-/* In-process cache of <intf_name, sockaddr_in> populated from *INTERFACE
-   table events. Lets us replay an INTERFACE_UPDATE for a vlan whose
-   source_interface IP was already observed before the DHCPV4_RELAY
-   config for that vlan landed in vlans_copy. */
-std::unordered_map<std::string, sockaddr_in> intf_to_addr_cache;
+// Source-interface IP events can arrive before the matching relay config.
+static std::unordered_map<std::string, sockaddr_in> intf_to_addr_cache;
 
 #ifdef UNIT_TEST
 using namespace swss;
@@ -110,21 +107,18 @@ void DHCPMgr::handle_swss_notification() {
             SWSS_LOG_INFO("[DHCPV4_RELAY] No DHCPV4_RELAY entries present at startup");
         }
 
-        /* Drain the *INTERFACE SubscriberStateTable buffers (already seeded
-           with the CONFIG_DB snapshot at construction time) before the
-           barrier. process_interface_notification populates
-           intf_to_addr_cache and dispatches INTERFACE_UPDATE for vlans
-           registered above so the main thread applies the correct
-           src_intf_sel_addr as part of the initial sync. */
+        // Drain interface snapshots before barrier to apply cached source_interface IPs.
         std::deque<swss::KeyOpFieldsValuesTuple> intf_entries;
         config_db_loopback_table.pops(intf_entries);
         if (!intf_entries.empty()) {
             process_interface_notification(intf_entries);
         }
+        intf_entries.clear();
         config_db_interface_table.pops(intf_entries);
         if (!intf_entries.empty()) {
             process_interface_notification(intf_entries);
         }
+        intf_entries.clear();
         config_db_portchannel_table.pops(intf_entries);
         if (!intf_entries.empty()) {
             process_interface_notification(intf_entries);
@@ -155,19 +149,14 @@ void DHCPMgr::handle_swss_notification() {
             continue;
         }
 
+        entries.clear();
 	if (!feature_dhcp_server_enabled) {
             if (config_db_relaymgr_table_ptr && selectable == config_db_relaymgr_table_ptr.get()) {
                 config_db_relaymgr_table_ptr->pops(entries);
                 process_relay_notification(entries);
-                /* Runtime: a DHCPV4_RELAY batch may register a vlan whose
-                   source_interface IP was cached by an earlier *INTERFACE
-                   event but never dispatched (vlans_copy didn't yet
-                   contain the vlan at that point). Replay from the
-                   in-process cache so the main thread overwrites any
-                   src_intf_sel_addr=0 set by prepare_relay_interface_config()
-                   before relayed packets arrive. */
                 if (!entries.empty()) {
-                    dispatch_source_intf_from_cache();
+                    // Keep replay scoped to this DHCPV4_RELAY batch.
+                    dispatch_source_intf_from_cache(entries);
                 }
             } else if (selectable == static_cast<swss::Selectable *>(&config_db_interface_table)) {
                 config_db_interface_table.pops(entries);
@@ -348,11 +337,6 @@ void DHCPMgr::process_interface_notification(std::deque<swss::KeyOpFieldsValuesT
             continue;
         }
 
-        /* Update intf_to_addr_cache (IPv4 only). Captures the IP for
-           any vlan whose source_interface gets configured later, so a
-           DHCPV4_RELAY batch arriving after the *INTERFACE event can
-           still recover the correct src_intf_sel_addr without a Redis
-           hit. */
         if (ip.find(':') == std::string::npos) {
             if (operation == "SET") {
                 sockaddr_in tmp{};
@@ -509,23 +493,22 @@ void DHCPMgr::process_relay_notification(std::deque<swss::KeyOpFieldsValuesTuple
     }
 }
 
-/**
- * @brief Dispatch INTERFACE_UPDATE events from intf_to_addr_cache.
- *
- * For every vlan in vlans_copy with a configured source_interface that has
- * an entry in intf_to_addr_cache, push a DHCPv4_RELAY_INTERFACE_UPDATE
- * event down config_pipe. Pure in-process: no Redis access. Invoked after
- * a runtime DHCPV4_RELAY batch to recover an IP that *INTERFACE
- * notifications recorded into the cache before the matching vlan was in
- * vlans_copy. Idempotent against the existing INTERFACE_UPDATE flow.
- */
-void DHCPMgr::dispatch_source_intf_from_cache() {
-    if (vlans_copy.empty() || intf_to_addr_cache.empty()) {
+void DHCPMgr::dispatch_source_intf_from_cache(const std::deque<swss::KeyOpFieldsValuesTuple> &entries) {
+    if (entries.empty() || intf_to_addr_cache.empty()) {
         return;
     }
 
-    for (auto &vlan_entry : vlans_copy) {
-        const std::string &intf = vlan_entry.second.source_interface;
+    for (const auto &entry : entries) {
+        if (kfvOp(entry) != "SET") {
+            continue;
+        }
+
+        auto vlan_entry = vlans_copy.find(kfvKey(entry));
+        if (vlan_entry == vlans_copy.end()) {
+            continue;
+        }
+
+        const std::string &intf = vlan_entry->second.source_interface;
         if (intf.empty()) {
             continue;
         }
@@ -543,7 +526,7 @@ void DHCPMgr::dispatch_source_intf_from_cache() {
             return;
         }
 
-        relay_msg->vlan = vlan_entry.second.vlan;
+        relay_msg->vlan = vlan_entry->second.vlan;
         relay_msg->is_add = true;
         relay_msg->src_intf_sel_addr = it->second;
 

--- a/dhcp4relay/src/dhcp4relay_mgr.h
+++ b/dhcp4relay/src/dhcp4relay_mgr.h
@@ -27,6 +27,11 @@ class DHCPMgr {
     void stop_db_updates();
     void process_relay_notification(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
     void process_interface_notification(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
+    /* Replay INTERFACE_UPDATE events from the in-process intf_to_addr_cache
+       for any vlan in vlans_copy whose source_interface has a cached IP.
+       Called after a runtime DHCPV4_RELAY batch so a missing getifaddrs()
+       result for the source IP does not leave src_intf_sel_addr at 0.0.0.0. */
+    void dispatch_source_intf_from_cache();
     void process_device_metadata_notification(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
     void process_vlan_member_notification(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
     void process_vlan_interface_notification(std::deque<swss::KeyOpFieldsValuesTuple> &entries);

--- a/dhcp4relay/src/dhcp4relay_mgr.h
+++ b/dhcp4relay/src/dhcp4relay_mgr.h
@@ -27,11 +27,7 @@ class DHCPMgr {
     void stop_db_updates();
     void process_relay_notification(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
     void process_interface_notification(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
-    /* Replay INTERFACE_UPDATE events from the in-process intf_to_addr_cache
-       for any vlan in vlans_copy whose source_interface has a cached IP.
-       Called after a runtime DHCPV4_RELAY batch so a missing getifaddrs()
-       result for the source IP does not leave src_intf_sel_addr at 0.0.0.0. */
-    void dispatch_source_intf_from_cache();
+    void dispatch_source_intf_from_cache(const std::deque<swss::KeyOpFieldsValuesTuple> &entries);
     void process_device_metadata_notification(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
     void process_vlan_member_notification(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
     void process_vlan_interface_notification(std::deque<swss::KeyOpFieldsValuesTuple> &entries);

--- a/dhcp4relay/test/mock_relay.cpp
+++ b/dhcp4relay/test/mock_relay.cpp
@@ -650,6 +650,66 @@ TEST(DHCPMgrTest, process_vlan_events) {
     dhcpMgr.process_vlan_notification(entries);
 }
 
+TEST(DHCPMgrTest, replay_cached_source_interface_for_updated_relay_entries) {
+    DHCPMgr dhcpMgr;
+    vlans_copy.clear();
+    testing_db::reset();
+
+    std::deque<swss::KeyOpFieldsValuesTuple> intf_entries;
+    intf_entries.emplace_back("Loopback4096|10.10.10.1/32", "DEL", std::vector<swss::FieldValueTuple>{});
+    dhcpMgr.process_interface_notification(intf_entries);
+
+    intf_entries.clear();
+    intf_entries.emplace_back("Loopback4096|10.10.10.1/32", "SET", std::vector<swss::FieldValueTuple>{
+        {"NULL", "NULL"}
+    });
+    dhcpMgr.process_interface_notification(intf_entries);
+
+    relay_config existing_config{};
+    existing_config.vlan = "Vlan200";
+    existing_config.source_interface = "Loopback4096";
+    existing_config.servers = {"192.0.2.1"};
+    vlans_copy[existing_config.vlan] = existing_config;
+
+    std::vector<event_type> written_types;
+    std::vector<std::string> replayed_vlans;
+    EXPECT_GLOBAL_CALL(write, write(_, _, _))
+        .Times(2)
+        .WillRepeatedly(Invoke([&](int, const void *buf, size_t count) -> ssize_t {
+            EXPECT_EQ(count, sizeof(event_config));
+
+            const auto *event = static_cast<const event_config *>(buf);
+            written_types.push_back(event->type);
+
+            auto *relay_msg = static_cast<relay_config *>(event->msg);
+            if (event->type == DHCPv4_RELAY_INTERFACE_UPDATE) {
+                replayed_vlans.push_back(relay_msg->vlan);
+                EXPECT_EQ(relay_msg->src_intf_sel_addr.sin_addr.s_addr, inet_addr("10.10.10.1"));
+            }
+
+            delete relay_msg;
+            return static_cast<ssize_t>(count);
+        }));
+
+    std::deque<swss::KeyOpFieldsValuesTuple> relay_entries;
+    relay_entries.emplace_back("Vlan100", "SET", std::vector<swss::FieldValueTuple>{
+        {"dhcpv4_servers", "192.0.2.10"},
+        {"source_interface", "Loopback4096"}
+    });
+
+    dhcpMgr.process_relay_notification(relay_entries);
+    dhcpMgr.dispatch_source_intf_from_cache(relay_entries);
+
+    EXPECT_THAT(written_types, ElementsAre(DHCPv4_RELAY_CONFIG_UPDATE, DHCPv4_RELAY_INTERFACE_UPDATE));
+    EXPECT_THAT(replayed_vlans, ElementsAre("Vlan100"));
+
+    vlans_copy.clear();
+    intf_entries.clear();
+    intf_entries.emplace_back("Loopback4096|10.10.10.1/32", "DEL", std::vector<swss::FieldValueTuple>{});
+    dhcpMgr.process_interface_notification(intf_entries);
+    testing_db::reset();
+}
+
 TEST(DHCPMgrTest, dhcp_server_feature_enable) {
     DHCPMgr dhcpMgr;
     EXPECT_GLOBAL_CALL(write, write(_, _, _))


### PR DESCRIPTION
When a large batch of DHCPV4_RELAY VLANs is configured alongside their underlying VLAN_INTERFACEs and a Loopback used as source_interface, the first ~10 VLANs silently drop relayed DHCP packets with "No IPv4 address configured".

Root cause: prepare_relay_interface_config() resolves the source interface IP via getifaddrs(). At scale, intfmgrd has not yet programmed the Loopback IP into the kernel by the time the DHCPV4_RELAY config arrives, so getifaddrs() misses it, src_intf_sel_addr is left at 0.0.0.0, and from_client() drops every packet for those VLANs. The authoritative source IP is already known to the dhcp4relay process at that point (as a *INTERFACE pub/sub event has either landed in the SubscriberStateTable buffer or already passed through process_interface_notification with no matching vlan in vlans_copy); only the kernel state is behind.

Fix: maintain an in-process intf_to_addr_cache map populated as a side-effect of process_interface_notification, and dispatch DHCPv4_RELAY_INTERFACE_UPDATE from that cache when a DHCPV4_RELAY batch registers a vlan whose source_interface IP was cached but never replayed. No Redis access on the hot path.

Wired in two places:

  - In the startup predrain block of handle_swss_notification(), after process_relay_notification(initial_entries) and before the DHCPv4_RELAY_SYNC_BARRIER write, drain the *INTERFACE SubscriberStateTables and feed them through process_interface_notification. The buffers were seeded by their construction-time SCAN, so this both populates the cache and dispatches INTERFACE_UPDATE for vlans registered by the relay drain immediately above.

  - In the runtime select loop, immediately after the DHCPV4_RELAY branch's process_relay_notification(entries) call, replay matching cache entries via dispatch_source_intf_from_cache() so a vlan whose source_interface IP arrived earlier (and was discarded by process_interface_notification because vlans_copy didn't yet contain the vlan) still receives a correct src_intf_sel_addr before any packet reaches prepare_relay_interface_config().

INTERFACE_UPDATE is the same event type produced by process_interface_notification, so the main thread handler in dhcp4relay.cpp needs no change. Idempotent: the existing kernel-driven INTERFACE flow simply rewrites the same src_intf_sel_addr if it later delivers another event for the same interface.