### PR TITLE
ci: migrate libyang1 deb install to libyang3

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -76,8 +76,8 @@ jobs:
       ${{ else }}:
         artifact: common-lib.${{ parameters.arch }}
       patterns: |
-        target/debs/bookworm/libyang-*_1.0*.deb
-        target/debs/bookworm/libyang_1.0*.deb
+        target/debs/bookworm/libyang3_*.deb
+        target/debs/bookworm/libyang-dev_3*.deb
     displayName: "Download libyang from common lib"
   - script: |
       set -ex

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,6 +48,7 @@ jobs:
             libnl-route-3-dev \
             libnl-nf-3-dev \
             libnl-genl-3-dev \
+            libyang-dev \
             libgmock-dev \
             dh-exec \
             swig \
@@ -77,13 +78,9 @@ jobs:
           curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm/libnl-genl-3-dev_3.7.0-0.2%2Bb1sonic1_amd64.deb" -o libnl-genl-3-dev_3.7.0-0.2+b1sonic1_amd64.deb
           curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm/libnl-nf-3-200_3.7.0-0.2%2Bb1sonic1_amd64.deb" -o libnl-nf-3-200_3.7.0-0.2+b1sonic1_amd64.deb
           curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm/libnl-nf-3-dev_3.7.0-0.2%2Bb1sonic1_amd64.deb" -o libnl-nf-3-dev_3.7.0-0.2+b1sonic1_amd64.deb
-          curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm/libyang_1.0.73_amd64.deb" -o libyang_1.0.73_amd64.deb
-          curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm/libyang-cpp_1.0.73_amd64.deb" -o llibyang-cpp_1.0.73_amd64.deb
-          curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm/libyang-dev_1.0.73_amd64.deb" -o libyang-dev_1.0.73_amd64.deb
           dpkg-deb -x libswsscommon_1.0.0_amd64.deb $(dirname $GITHUB_WORKSPACE)
           dpkg-deb -x libswsscommon-dev_1.0.0_amd64.deb $(dirname $GITHUB_WORKSPACE)
           dpkg -i libnl*.deb
-          dpkg -i libyang*.deb
 
       - name: build
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -77,8 +77,12 @@ jobs:
           curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm/libnl-genl-3-dev_3.7.0-0.2%2Bb1sonic1_amd64.deb" -o libnl-genl-3-dev_3.7.0-0.2+b1sonic1_amd64.deb
           curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm/libnl-nf-3-200_3.7.0-0.2%2Bb1sonic1_amd64.deb" -o libnl-nf-3-200_3.7.0-0.2+b1sonic1_amd64.deb
           curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm/libnl-nf-3-dev_3.7.0-0.2%2Bb1sonic1_amd64.deb" -o libnl-nf-3-dev_3.7.0-0.2+b1sonic1_amd64.deb
-          curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm/libyang3_3.12.2-1_amd64.deb" -o libyang3_3.12.2-1_amd64.deb
-          curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm/libyang-dev_3.12.2-1_amd64.deb" -o libyang-dev_3.12.2-1_amd64.deb
+          # The sonic-build artifacts REST API requires an exact filename in
+          # target= (wildcards do not resolve), so to stay version-independent
+          # across libyang3 bumps we fetch the whole bookworm debs directory as
+          # a zip and extract just the libyang3 debs with a glob.
+          curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm&format=zip" -o bookworm-debs.zip
+          unzip -j -o bookworm-debs.zip '*/libyang3_*.deb' '*/libyang-dev_*.deb'
           dpkg-deb -x libswsscommon_1.0.0_amd64.deb $(dirname $GITHUB_WORKSPACE)
           dpkg-deb -x libswsscommon-dev_1.0.0_amd64.deb $(dirname $GITHUB_WORKSPACE)
           dpkg -i libnl*.deb

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,6 @@ jobs:
             libnl-route-3-dev \
             libnl-nf-3-dev \
             libnl-genl-3-dev \
-            libyang-dev \
             libgmock-dev \
             dh-exec \
             swig \
@@ -78,9 +77,12 @@ jobs:
           curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm/libnl-genl-3-dev_3.7.0-0.2%2Bb1sonic1_amd64.deb" -o libnl-genl-3-dev_3.7.0-0.2+b1sonic1_amd64.deb
           curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm/libnl-nf-3-200_3.7.0-0.2%2Bb1sonic1_amd64.deb" -o libnl-nf-3-200_3.7.0-0.2+b1sonic1_amd64.deb
           curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm/libnl-nf-3-dev_3.7.0-0.2%2Bb1sonic1_amd64.deb" -o libnl-nf-3-dev_3.7.0-0.2+b1sonic1_amd64.deb
+          curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm/libyang3_3.12.2-1_amd64.deb" -o libyang3_3.12.2-1_amd64.deb
+          curl -L "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm/libyang-dev_3.12.2-1_amd64.deb" -o libyang-dev_3.12.2-1_amd64.deb
           dpkg-deb -x libswsscommon_1.0.0_amd64.deb $(dirname $GITHUB_WORKSPACE)
           dpkg-deb -x libswsscommon-dev_1.0.0_amd64.deb $(dirname $GITHUB_WORKSPACE)
           dpkg -i libnl*.deb
+          dpkg -i libyang*.deb
 
       - name: build
         run: |

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -15,7 +15,6 @@ extraction:
       - "swig3.0"
       - "uuid-dev"
       - "libzmq3-dev"
-      - "libyang"
       - "libyang-dev"
     after_prepare:
     - "git clone https://github.com/Azure/sonic-swss-common; pushd sonic-swss-common; ./autogen.sh; fakeroot dpkg-buildpackage -us -uc -b; popd"


### PR DESCRIPTION
#### Why I did it

`sonic-buildimage` no longer builds the legacy libyang1 debs (`libyang_1.0.73`, `libyang-cpp`, `python3-yang`); it now builds only libyang3 (`libyang3`, `python3-libyang`). The CI here still referenced the libyang1 debs and would break once libyang1 is gone.

Part of the libyang3 migration tracked in sonic-net/sonic-buildimage#22385.

#### How I did it

- **`.azure-pipelines/build.yml`** — download the libyang3 debs from the `common_libs` artifact using versionless globs (`libyang3_*.deb`, `libyang-dev_*.deb`) instead of the libyang1 patterns.
- **`.github/workflows/codeql-analysis.yml`** — install `libyang-dev` from the distro apt repo in the `prepare` step (the same approach the other SONiC repos' CodeQL workflows already use — e.g. sonic-sairedis, sonic-linkmgrd, sonic-wpa-supplicant) and drop the hardcoded `sonic-build` libyang1 deb downloads. This avoids pinning a libyang version in the workflow.
- **`lgtm.yml`** — keep the apt-provided `libyang-dev`; drop the bare `libyang` entry.

#### How to verify it

The azure build downloads/install the libyang3 debs from current `sonic-buildimage` master; the CodeQL build resolves libyang headers from the distro `libyang-dev`, consistent with the other repos. No libyang version is hardcoded anywhere.

#### Description for the changelog

ci: migrate libyang1 references to libyang3 (azure build artifacts + CodeQL).
