### PR TITLE
[dhcp6relay] Add VRF support for upstream sockets (VLAN vrf and server_vrf)

### DIFF
--- a/dhcp6relay/src/config_interface.cpp
+++ b/dhcp6relay/src/config_interface.cpp
@@ -163,6 +163,7 @@ void processRelayNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries,
         intf.mux_key = "";
         intf.state_db = nullptr;
         intf.is_lla_ready = false;
+        std::string server_vrf;
         for (auto &fieldValue: fieldValues) {
             std::string f = fvField(fieldValue);
             std::string v = fvValue(fieldValue);
@@ -181,13 +182,32 @@ void processRelayNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries,
             if(f == "dhcpv6_option|interface_id" && v == "true") { // interface-id is off by default on non-Dual-ToR, unless specified in config db
                 intf.is_interface_id = true;
             }
+            if(f == SERVER_VRF_FIELD) {
+                server_vrf = v;
+            }
         }
+        // The upstream (gua) socket binds to the VLAN's own VRF (vrf_name), so a
+        // VLAN placed in a non-default VRF reaches servers reachable in that VRF.
+        intf.vrf = DEFAULT_VRF;
+        {
+            std::string vlan_vrf;
+            swss::Table vlan_intf_table(config_db.get(), "VLAN_INTERFACE");
+            vlan_intf_table.hget(vlan, VRF_NAME_FIELD, vlan_vrf);
+            if (!vlan_vrf.empty()) {
+                intf.vrf = vlan_vrf;
+            }
+        }
+        // An explicit server_vrf only matters when the servers live in a VRF
+        // different from the VLAN's own; otherwise the gua socket already reaches
+        // them. Empty server_vrf selects the same-VRF (gua socket) path.
+        intf.server_vrf = (!server_vrf.empty() && server_vrf != intf.vrf) ? server_vrf : "";
         if (intf.servers.empty()) {
             syslog(LOG_WARNING, "No servers found for VLAN %s, skipping configuration.", vlan.c_str());
             continue;
         }
-        syslog(LOG_INFO, "add %s relay config, option79 %s interface-id %s\n", vlan.c_str(),
-               intf.is_option_79 ? "enable" : "disable", intf.is_interface_id ? "enable" : "disable");
+        syslog(LOG_INFO, "add %s relay config, option79 %s interface-id %s vrf %s server_vrf %s\n", vlan.c_str(),
+               intf.is_option_79 ? "enable" : "disable", intf.is_interface_id ? "enable" : "disable",
+               intf.vrf.c_str(), intf.server_vrf.empty() ? "-" : intf.server_vrf.c_str());
         vlans[vlan] = intf;
     }
 }

--- a/dhcp6relay/src/config_interface.cpp
+++ b/dhcp6relay/src/config_interface.cpp
@@ -1,12 +1,26 @@
 #include <sstream>
 #include <syslog.h>
 #include <algorithm>
+#include <atomic>
+#include <deque>
+#include <mutex>
+#include <thread>
+#include <unistd.h>
 #include "config_interface.h"
 
 constexpr auto DEFAULT_TIMEOUT_MSEC = 1000;
 
 bool pollSwssNotifcation = true;
 swss::Select swssSelect;
+
+// Runtime config monitor state: the monitor thread publishes the desired
+// per-vlan config under g_cfg_mutex and wakes the main loop via g_notify_fd;
+// config_change_callback reconciles it with the live vlans map.
+static std::mutex g_cfg_mutex;
+static std::unordered_map<std::string, relay_config> g_desired_cfg;
+static std::thread g_monitor_thread;
+static std::atomic<bool> g_stop_monitor{false};
+static int g_notify_fd = -1;
 
 /**
  * @code                void initialize_swss()
@@ -21,7 +35,7 @@ void initialize_swss(std::unordered_map<std::string, relay_config> &vlans)
         std::shared_ptr<swss::DBConnector> configDbPtr = std::make_shared<swss::DBConnector> ("CONFIG_DB", 0);
         swss::SubscriberStateTable ipHelpersTable(configDbPtr.get(), "DHCP_RELAY");
         swssSelect.addSelectable(&ipHelpersTable);
-        get_dhcp(vlans, &ipHelpersTable, false, configDbPtr);
+        get_dhcp(vlans, &ipHelpersTable, configDbPtr);
     }
     catch (const std::bad_alloc &e) {
         syslog(LOG_ERR, "Failed allocate memory. Exception details: %s", e.what());
@@ -53,14 +67,14 @@ void deinitialize_swss()
 
 /**
 
- * @code                void get_dhcp(std::unordered_map<std::string, relay_config> &vlans, swss::SubscriberStateTable *ipHelpersTable, bool dynamic,
+ * @code                void get_dhcp(std::unordered_map<std::string, relay_config> &vlans, swss::SubscriberStateTable *ipHelpersTable,
                                       std::shared_ptr<swss::DBConnector> config_db)
  * 
  * @brief               initialize and get vlan table information from DHCP_RELAY
  *
  * @return              none
  */
-void get_dhcp(std::unordered_map<std::string, relay_config> &vlans, swss::SubscriberStateTable *ipHelpersTable, bool dynamic,
+void get_dhcp(std::unordered_map<std::string, relay_config> &vlans, swss::SubscriberStateTable *ipHelpersTable,
               std::shared_ptr<swss::DBConnector> config_db) {
     swss::Selectable *selectable;
     int ret = swssSelect.select(&selectable, DEFAULT_TIMEOUT_MSEC);
@@ -70,12 +84,7 @@ void get_dhcp(std::unordered_map<std::string, relay_config> &vlans, swss::Subscr
     } else if (ret == swss::Select::TIMEOUT) {
     } 
     if (selectable == static_cast<swss::Selectable *> (ipHelpersTable)) {
-        if (!dynamic) {
-            handleRelayNotification(*ipHelpersTable, vlans, config_db);
-        } else {
-            syslog(LOG_WARNING, "relay config changed, "
-                   "need restart container to take effect");
-        }
+        handleRelayNotification(*ipHelpersTable, vlans, config_db);
     }
 }
 
@@ -206,4 +215,138 @@ bool check_is_lla_ready(std::string vlan) {
         }
     }
     return false;
+}
+
+/**
+ * @code                std::unordered_map<std::string, relay_config> build_desired_config(std::shared_ptr<swss::DBConnector> config_db)
+ *
+ * @brief               read the full DHCP_RELAY table and build the desired per-vlan relay config
+ *
+ * @param config_db     CONFIG_DB connector used to read DHCP_RELAY and VLAN_INTERFACE
+ *
+ * @return              desired map of vlan name to relay_config (config fields only)
+ */
+std::unordered_map<std::string, relay_config> build_desired_config(std::shared_ptr<swss::DBConnector> config_db)
+{
+    std::unordered_map<std::string, relay_config> desired;
+    swss::Table dhcp_relay_table(config_db.get(), "DHCP_RELAY");
+    std::vector<std::string> keys;
+    dhcp_relay_table.getKeys(keys);
+
+    std::deque<swss::KeyOpFieldsValuesTuple> entries;
+    for (const auto &key : keys) {
+        std::vector<swss::FieldValueTuple> field_values;
+        dhcp_relay_table.get(key, field_values);
+        entries.emplace_back(key, "SET", field_values);
+    }
+    // Reuse the notification parser so the server list, options and the
+    // VLAN_INTERFACE IPv6-presence check stay in one code path.
+    processRelayNotification(entries, desired, config_db);
+    return desired;
+}
+
+/**
+ * @code                static void publish_desired_config(std::shared_ptr<swss::DBConnector> config_db)
+ *
+ * @brief               snapshot the desired config, store it under lock and wake the main loop
+ *
+ * @param config_db     CONFIG_DB connector used to read the desired config
+ *
+ * @return              none
+ */
+static void publish_desired_config(std::shared_ptr<swss::DBConnector> config_db)
+{
+    auto desired = build_desired_config(config_db);
+    {
+        std::lock_guard<std::mutex> lock(g_cfg_mutex);
+        g_desired_cfg = std::move(desired);
+    }
+    if (g_notify_fd >= 0) {
+        char notify_byte = 1;
+        ssize_t written = write(g_notify_fd, &notify_byte, sizeof(notify_byte));
+        if (written < 0) {
+            syslog(LOG_WARNING, "Failed to notify main loop of config change: %s", strerror(errno));
+        }
+    }
+}
+
+/**
+ * @code                static void config_monitor_loop()
+ *
+ * @brief               detached thread: watch CONFIG_DB tables and publish desired config on change
+ *
+ * @return              none
+ */
+static void config_monitor_loop()
+{
+    auto config_db = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
+    auto state_db = std::make_shared<swss::DBConnector>("STATE_DB", 0);
+    swss::SubscriberStateTable dhcpRelaySub(config_db.get(), "DHCP_RELAY");
+    swss::SubscriberStateTable vlanIntfSub(config_db.get(), "VLAN_INTERFACE");
+    swss::SubscriberStateTable vlanSub(config_db.get(), "VLAN");
+    // STATE_DB INTERFACE_TABLE signals interface readiness (link-local address
+    // present). Watching it reconciles a vlan as soon as its interface comes up
+    // instead of waiting for the periodic 60s link-local check.
+    swss::SubscriberStateTable intfStateSub(state_db.get(), "INTERFACE_TABLE");
+
+    swss::Select select;
+    select.addSelectable(&dhcpRelaySub);
+    select.addSelectable(&vlanIntfSub);
+    select.addSelectable(&vlanSub);
+    select.addSelectable(&intfStateSub);
+
+    // Drain the initial snapshot the subscriber tables cache at construction so
+    // the first real notification is not preceded by a redundant reprocessing.
+    std::deque<swss::KeyOpFieldsValuesTuple> drain;
+    dhcpRelaySub.pops(drain);
+    vlanIntfSub.pops(drain);
+    vlanSub.pops(drain);
+    intfStateSub.pops(drain);
+
+    // Publish the current configuration once at startup.
+    publish_desired_config(config_db);
+
+    while (!g_stop_monitor.load()) {
+        swss::Selectable *selectable = nullptr;
+        int ret = select.select(&selectable, DEFAULT_TIMEOUT_MSEC);
+        if (ret == swss::Select::TIMEOUT) {
+            continue;
+        }
+        if (ret == swss::Select::ERROR) {
+            syslog(LOG_WARNING, "Select: returned ERROR in config monitor");
+            continue;
+        }
+
+        std::deque<swss::KeyOpFieldsValuesTuple> entries;
+        dhcpRelaySub.pops(entries);
+        entries.clear();
+        vlanIntfSub.pops(entries);
+        entries.clear();
+        vlanSub.pops(entries);
+        entries.clear();
+        intfStateSub.pops(entries);
+        entries.clear();
+
+        publish_desired_config(config_db);
+    }
+}
+
+void start_dhcp_config_monitor(int notify_fd)
+{
+    g_notify_fd = notify_fd;
+    g_stop_monitor.store(false);
+    g_monitor_thread = std::thread(config_monitor_loop);
+    g_monitor_thread.detach();
+}
+
+void stop_dhcp_config_monitor()
+{
+    g_stop_monitor.store(true);
+}
+
+bool fetch_desired_config(std::unordered_map<std::string, relay_config> &out)
+{
+    std::lock_guard<std::mutex> lock(g_cfg_mutex);
+    out = g_desired_cfg;
+    return true;
 }

--- a/dhcp6relay/src/config_interface.cpp
+++ b/dhcp6relay/src/config_interface.cpp
@@ -13,9 +13,7 @@ constexpr auto DEFAULT_TIMEOUT_MSEC = 1000;
 bool pollSwssNotifcation = true;
 swss::Select swssSelect;
 
-// Runtime config monitor state: the monitor thread publishes the desired
-// per-vlan config under g_cfg_mutex and wakes the main loop via g_notify_fd;
-// config_change_callback reconciles it with the live vlans map.
+// Config-monitor thread state: publishes desired config under g_cfg_mutex, wakes the main loop via g_notify_fd.
 static std::mutex g_cfg_mutex;
 static std::unordered_map<std::string, relay_config> g_desired_cfg;
 static std::thread g_monitor_thread;
@@ -186,8 +184,7 @@ void processRelayNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries,
                 server_vrf = v;
             }
         }
-        // The upstream (gua) socket binds to the VLAN's own VRF (vrf_name), so a
-        // VLAN placed in a non-default VRF reaches servers reachable in that VRF.
+        // The gua socket binds to the VLAN's own vrf_name, so a VLAN in a non-default VRF reaches servers in that VRF.
         intf.vrf = DEFAULT_VRF;
         {
             std::string vlan_vrf;
@@ -197,9 +194,7 @@ void processRelayNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries,
                 intf.vrf = vlan_vrf;
             }
         }
-        // An explicit server_vrf only matters when the servers live in a VRF
-        // different from the VLAN's own; otherwise the gua socket already reaches
-        // them. Empty server_vrf selects the same-VRF (gua socket) path.
+        // An explicit server_vrf only applies when servers live in a different VRF than the VLAN's; empty selects the same-VRF path.
         intf.server_vrf = (!server_vrf.empty() && server_vrf != intf.vrf) ? server_vrf : "";
         if (intf.servers.empty()) {
             syslog(LOG_WARNING, "No servers found for VLAN %s, skipping configuration.", vlan.c_str());
@@ -259,8 +254,7 @@ std::unordered_map<std::string, relay_config> build_desired_config(std::shared_p
         dhcp_relay_table.get(key, field_values);
         entries.emplace_back(key, "SET", field_values);
     }
-    // Reuse the notification parser so the server list, options and the
-    // VLAN_INTERFACE IPv6-presence check stay in one code path.
+    // Reuse the notification parser to keep parsing in one code path.
     processRelayNotification(entries, desired, config_db);
     return desired;
 }
@@ -293,7 +287,7 @@ static void publish_desired_config(std::shared_ptr<swss::DBConnector> config_db)
 /**
  * @code                static void config_monitor_loop()
  *
- * @brief               detached thread: watch CONFIG_DB tables and publish desired config on change
+ * @brief               monitor thread: watch CONFIG_DB tables and publish desired config on change
  *
  * @return              none
  */
@@ -304,9 +298,7 @@ static void config_monitor_loop()
     swss::SubscriberStateTable dhcpRelaySub(config_db.get(), "DHCP_RELAY");
     swss::SubscriberStateTable vlanIntfSub(config_db.get(), "VLAN_INTERFACE");
     swss::SubscriberStateTable vlanSub(config_db.get(), "VLAN");
-    // STATE_DB INTERFACE_TABLE signals interface readiness (link-local address
-    // present). Watching it reconciles a vlan as soon as its interface comes up
-    // instead of waiting for the periodic 60s link-local check.
+    // Watch STATE_DB INTERFACE_TABLE to reconcile a vlan as soon as its interface is up.
     swss::SubscriberStateTable intfStateSub(state_db.get(), "INTERFACE_TABLE");
 
     swss::Select select;
@@ -315,16 +307,18 @@ static void config_monitor_loop()
     select.addSelectable(&vlanSub);
     select.addSelectable(&intfStateSub);
 
-    // Drain the initial snapshot the subscriber tables cache at construction so
-    // the first real notification is not preceded by a redundant reprocessing.
+    // Drain the initial cached snapshot to avoid a redundant first reprocess.
     std::deque<swss::KeyOpFieldsValuesTuple> drain;
     dhcpRelaySub.pops(drain);
     vlanIntfSub.pops(drain);
     vlanSub.pops(drain);
     intfStateSub.pops(drain);
 
-    // Publish the current configuration once at startup.
-    publish_desired_config(config_db);
+    try {
+        publish_desired_config(config_db);
+    } catch (const std::exception &e) {
+        syslog(LOG_WARNING, "config monitor: initial publish failed, will retry on next change: %s", e.what());
+    }
 
     while (!g_stop_monitor.load()) {
         swss::Selectable *selectable = nullptr;
@@ -337,31 +331,44 @@ static void config_monitor_loop()
             continue;
         }
 
-        std::deque<swss::KeyOpFieldsValuesTuple> entries;
-        dhcpRelaySub.pops(entries);
-        entries.clear();
-        vlanIntfSub.pops(entries);
-        entries.clear();
-        vlanSub.pops(entries);
-        entries.clear();
-        intfStateSub.pops(entries);
-        entries.clear();
+        try {
+            std::deque<swss::KeyOpFieldsValuesTuple> entries;
+            dhcpRelaySub.pops(entries);
+            entries.clear();
+            vlanIntfSub.pops(entries);
+            entries.clear();
+            vlanSub.pops(entries);
+            entries.clear();
+            intfStateSub.pops(entries);
+            entries.clear();
 
-        publish_desired_config(config_db);
+            publish_desired_config(config_db);
+        } catch (const std::exception &e) {
+            // A transient CONFIG_DB error must not crash the relay; log and retry.
+            syslog(LOG_WARNING, "config monitor: reconcile failed, will retry: %s", e.what());
+        }
     }
 }
 
 void start_dhcp_config_monitor(int notify_fd)
 {
+    // Stop any previous monitor before starting a new one.
+    if (g_monitor_thread.joinable()) {
+        stop_dhcp_config_monitor();
+    }
     g_notify_fd = notify_fd;
     g_stop_monitor.store(false);
     g_monitor_thread = std::thread(config_monitor_loop);
-    g_monitor_thread.detach();
 }
 
 void stop_dhcp_config_monitor()
 {
     g_stop_monitor.store(true);
+    // Join before shutdown_relay tears down the state the thread uses.
+    if (g_monitor_thread.joinable()) {
+        g_monitor_thread.join();
+    }
+    g_notify_fd = -1;
 }
 
 bool fetch_desired_config(std::unordered_map<std::string, relay_config> &out)

--- a/dhcp6relay/src/config_interface.h
+++ b/dhcp6relay/src/config_interface.h
@@ -33,14 +33,14 @@ void initialize_swss(std::unordered_map<std::string, relay_config> &vlans);
 void deinitialize_swss();
 
 /**
- * @code                void get_dhcp(std::unordered_map<std::string, relay_config> &vlans, swss::SubscriberStateTable *ipHelpersTable, bool dynamic,
+ * @code                void get_dhcp(std::unordered_map<std::string, relay_config> &vlans, swss::SubscriberStateTable *ipHelpersTable,
  *                                    std::shared_ptr<swss::DBConnector> config_db)
  * 
  * @brief               initialize and get vlan information from DHCP_RELAY
  *
  * @return              none
  */
-void get_dhcp(std::unordered_map<std::string, relay_config> &vlans, swss::SubscriberStateTable *ipHelpersTable, bool dynamic,
+void get_dhcp(std::unordered_map<std::string, relay_config> &vlans, swss::SubscriberStateTable *ipHelpersTable,
               std::shared_ptr<swss::DBConnector> config_db);
 
 /**
@@ -81,3 +81,45 @@ void processRelayNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries,
  * @return                  bool value indicates whether lla ready
  */
 bool check_is_lla_ready(std::string vlan);
+
+/**
+ * @code                build_desired_config(std::shared_ptr<swss::DBConnector> config_db);
+ *
+ * @brief               read the full DHCP_RELAY table and build the desired per-vlan relay config
+ *
+ * @param config_db     CONFIG_DB connector used to read DHCP_RELAY and VLAN_INTERFACE
+ *
+ * @return              desired map of vlan name to relay_config (config fields only)
+ */
+std::unordered_map<std::string, relay_config> build_desired_config(std::shared_ptr<swss::DBConnector> config_db);
+
+/**
+ * @code                start_dhcp_config_monitor(int notify_fd);
+ *
+ * @brief               start the detached thread that watches CONFIG_DB and publishes desired config
+ *
+ * @param notify_fd     write end of the pipe used to wake the libevent main loop
+ *
+ * @return              none
+ */
+void start_dhcp_config_monitor(int notify_fd);
+
+/**
+ * @code                stop_dhcp_config_monitor();
+ *
+ * @brief               signal the config monitor thread to stop
+ *
+ * @return              none
+ */
+void stop_dhcp_config_monitor();
+
+/**
+ * @code                fetch_desired_config(std::unordered_map<std::string, relay_config> &out);
+ *
+ * @brief               copy the latest desired config published by the monitor thread
+ *
+ * @param out           map populated with the latest desired per-vlan relay config
+ *
+ * @return              true on success
+ */
+bool fetch_desired_config(std::unordered_map<std::string, relay_config> &out);

--- a/dhcp6relay/src/relay.cpp
+++ b/dhcp6relay/src/relay.cpp
@@ -21,6 +21,23 @@ static std::string counter_table = "DHCPv6_COUNTER_TABLE|";
 static uint8_t client_recv_buffer[BUFFER_SIZE];
 static uint8_t server_recv_buffer[BUFFER_SIZE];
 
+/* Shared upstream sockets for reaching DHCPv6 servers that live in an explicit
+ * server VRF (different from the client VLAN's VRF). One socket + listen-event
+ * per server VRF is shared by all vlans using it; the relay-reply is
+ * demultiplexed to the owning vlan by link-address (server_callback_vrf).
+ * Created on first use and released once the last vlan referencing it is
+ * removed or re-pointed (see release_server_vrf_sock_if_unused) so a deleted
+ * (and possibly recreated) server VRF does not leave a stale SO_BINDTODEVICE
+ * socket behind. The type/map/accessors are declared in relay.h (non-static) so
+ * the unit tests can verify the lifecycle. */
+std::map<std::string, server_vrf_socket> g_server_vrf_socks;
+
+/* Return the shared upstream socket fd for `vrf`, or -1 if it is not armed. */
+int lookup_server_vrf_sock(const std::string &vrf) {
+    auto it = g_server_vrf_socks.find(vrf);
+    return (it == g_server_vrf_socks.end()) ? -1 : it->second.sock;
+}
+
 /**
  * @code                bool should_log_throttled(const std::string &key);
  *
@@ -645,6 +662,23 @@ int prepare_vlan_sockets(int &gua_sock, int &lla_sock, relay_config &config) {
     evutil_make_listen_socket_reuseable(lla_sock);
     evutil_make_socket_nonblocking(lla_sock);
 
+    // Bind the upstream (gua) socket to the configured VRF so relay-forward
+    // messages to the DHCPv6 servers egress in that VRF's routing table. A
+    // non-default VRF requires SO_BINDTODEVICE to the VRF master device; the
+    // default (global) table needs no binding. The client-facing lla socket is
+    // link-scoped and stays on the vlan interface.
+    if (!config.vrf.empty() && config.vrf != DEFAULT_VRF) {
+        if (setsockopt(gua_sock, SOL_SOCKET, SO_BINDTODEVICE,
+                       config.vrf.c_str(), config.vrf.size()) < 0) {
+            syslog(LOG_ERR, "setsockopt: Failed to bind upstream socket for %s to VRF %s: %s\n",
+                   config.interface.c_str(), config.vrf.c_str(), strerror(errno));
+            close(gua_sock);
+            close(lla_sock);
+            return -1;
+        }
+        syslog(LOG_INFO, "Bound upstream socket for %s to VRF %s\n", config.interface.c_str(), config.vrf.c_str());
+    }
+
     int retry = 0;
     bool bind_gua = false;
     bool bind_lla = false;
@@ -766,6 +800,17 @@ void relay_client(const uint8_t *msg, uint16_t len, const ip6_hdr *ip_hdr, const
     if (dual_tor_sock) {
         sock = config->lo_sock;
     }
+    // Servers in an explicit (different) VRF are reached over the shared per-VRF
+    // socket so relay-forward egresses in that VRF and the reply returns on it.
+    if (!config->server_vrf.empty()) {
+        int vrf_sock = lookup_server_vrf_sock(config->server_vrf);
+        if (vrf_sock < 0) {
+            syslog(LOG_WARNING, "Server VRF socket for %s not ready, dropping relay-forward for %s\n",
+                   config->server_vrf.c_str(), config->interface.c_str());
+            return;
+        }
+        sock = vrf_sock;
+    }
     for(auto server: config->servers_sock) {
         if(send_udp(sock, relay_pkt, server, relay_pkt_len)) {
             increase_counter(config->state_db, config->interface, DHCPv6_MESSAGE_TYPE_RELAY_FORW);
@@ -826,6 +871,17 @@ void relay_relay_forw(const uint8_t *msg, int32_t len, const ip6_hdr *ip_hdr, re
     int sock = config->gua_sock;
     if (dual_tor_sock) {
         sock = config->lo_sock;
+    }
+    // Servers in an explicit (different) VRF are reached over the shared per-VRF
+    // socket so relay-forward egresses in that VRF and the reply returns on it.
+    if (!config->server_vrf.empty()) {
+        int vrf_sock = lookup_server_vrf_sock(config->server_vrf);
+        if (vrf_sock < 0) {
+            syslog(LOG_WARNING, "Server VRF socket for %s not ready, dropping relay-forward for %s\n",
+                   config->server_vrf.c_str(), config->interface.c_str());
+            return;
+        }
+        sock = vrf_sock;
     }
     for(auto server: config->servers_sock) {
         if(send_udp(sock, send_buffer, server, send_buffer_len)) {
@@ -1145,6 +1201,158 @@ void server_callback_dualtor(evutil_socket_t fd, short event, void *arg) {
         increase_counter(config->state_db, loopback_str, msg_type);
         relay_relay_reply(server_recv_buffer, buffer_sz, config);
     }
+}
+
+/**
+ * @code                void server_callback_vrf(evutil_socket_t fd, short event, void *arg);
+ *
+ * @brief               callback for a shared per-server-VRF upstream socket. All
+ *                      vlans whose servers live in this VRF share one socket; the
+ *                      relay-reply is demultiplexed to the owning vlan by its
+ *                      link-address, exactly like the dualtor loopback path.
+ *
+ * @param fd            the shared server-VRF socket
+ * @param event         libevent triggered event
+ * @param arg           pointer to the live vlans map
+ *
+ * @return              none
+ */
+void server_callback_vrf(evutil_socket_t fd, short event, void *arg) {
+    auto vlans = reinterpret_cast<std::unordered_map<std::string, struct relay_config> *>(arg);
+    sockaddr_in6 from;
+    socklen_t len = sizeof(from);
+    int32_t pkts_num = 0;
+
+    while (pkts_num++ < BATCH_SIZE) {
+        auto buffer_sz = recvfrom(fd, server_recv_buffer, BUFFER_SIZE, 0, (sockaddr *)&from, &len);
+        if (buffer_sz <= 0) {
+            if (errno != EAGAIN) {
+                syslog(LOG_ERR, "recv: Failed to receive data from server VRF socket: %s\n", strerror(errno));
+            }
+            return;
+        }
+
+        if (buffer_sz < (int32_t)sizeof(struct dhcpv6_msg)) {
+            syslog(LOG_WARNING, "Invalid DHCPv6 packet length %zd on server VRF socket\n", buffer_sz);
+            continue;
+        }
+
+        auto msg_type = parse_dhcpv6_hdr(server_recv_buffer)->msg_type;
+        if (msg_type != DHCPv6_MESSAGE_TYPE_RELAY_REPL) {
+            syslog(LOG_WARNING, "Invalid DHCPv6 message type %d received on server VRF socket\n", msg_type);
+            continue;
+        }
+        auto config = get_relay_int_from_relay_msg(server_recv_buffer, buffer_sz, vlans);
+        if (!config) {
+            syslog(LOG_WARNING, "Invalid DHCPv6 header content on server VRF socket, packet will be dropped\n");
+            continue;
+        }
+        if (!config->is_lla_ready) {
+            syslog(LOG_WARNING, "Link local address for %s is not ready, packet will be dropped\n", config->interface.c_str());
+            continue;
+        }
+        increase_counter(config->state_db, config->interface, msg_type);
+        relay_relay_reply(server_recv_buffer, buffer_sz, config);
+    }
+}
+
+/**
+ * @code                static int get_or_create_server_vrf_sock(const std::string &vrf, vlans);
+ *
+ * @brief               return the shared upstream socket for `vrf`, creating and
+ *                      arming it on first use. Bound in6addr_any:547 +
+ *                      SO_BINDTODEVICE(vrf) so the kernel sources relay-forward
+ *                      from an address valid in `vrf` and the relay-reply returns
+ *                      on the same socket.
+ *
+ * @param vrf           server VRF name (must be non-default, non-empty)
+ * @param vlans         live vlans map, used as the listen-event callback arg
+ *
+ * @return              socket fd on success, -1 on failure
+ */
+static int get_or_create_server_vrf_sock(const std::string &vrf,
+                                         std::unordered_map<std::string, struct relay_config> *vlans) {
+    auto it = g_server_vrf_socks.find(vrf);
+    if (it != g_server_vrf_socks.end()) {
+        return it->second.sock;
+    }
+
+    int sock = socket(AF_INET6, SOCK_DGRAM, 0);
+    if (sock < 0) {
+        syslog(LOG_ERR, "socket: Failed to create server VRF socket for %s: %s\n", vrf.c_str(), strerror(errno));
+        return -1;
+    }
+    evutil_make_listen_socket_reuseable(sock);
+    evutil_make_socket_nonblocking(sock);
+
+    if (setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, vrf.c_str(), vrf.size()) < 0) {
+        syslog(LOG_ERR, "setsockopt: Failed to bind server VRF socket to %s: %s\n", vrf.c_str(), strerror(errno));
+        close(sock);
+        return -1;
+    }
+
+    sockaddr_in6 any_addr = {};
+    any_addr.sin6_family = AF_INET6;
+    any_addr.sin6_addr = in6addr_any;
+    any_addr.sin6_port = htons(RELAY_PORT);
+    if (bind(sock, (sockaddr *)&any_addr, sizeof(any_addr)) < 0) {
+        syslog(LOG_ERR, "bind: Failed to bind server VRF socket for %s: %s\n", vrf.c_str(), strerror(errno));
+        close(sock);
+        return -1;
+    }
+
+    struct event *ev = event_new(base, sock, EV_READ | EV_PERSIST, server_callback_vrf, vlans);
+    if (ev == nullptr) {
+        syslog(LOG_ERR, "libevent: Failed to create server VRF listen event for %s\n", vrf.c_str());
+        close(sock);
+        return -1;
+    }
+    event_add(ev, NULL);
+    g_server_vrf_socks[vrf] = {sock, ev};
+    syslog(LOG_INFO, "Created shared upstream socket for server VRF %s\n", vrf.c_str());
+    return sock;
+}
+
+/**
+ * @code                static void release_server_vrf_sock_if_unused(const std::string &vrf, vlans);
+ *
+ * @brief               close and drop the shared upstream socket for `vrf` once
+ *                      no live vlan still references it as its server_vrf, so a
+ *                      server VRF that is deleted (and possibly recreated) does
+ *                      not leave a stale SO_BINDTODEVICE socket that
+ *                      get_or_create_server_vrf_sock would later hand back. Keeps
+ *                      the shared-socket lifecycle symmetric with the per-vlan
+ *                      upstream sockets freed in teardown_vlan_relay.
+ *
+ * @param vrf           server VRF whose socket may now be unreferenced
+ * @param vlans         live per-vlan relay config
+ *
+ * @return              none
+ */
+void release_server_vrf_sock_if_unused(
+        const std::string &vrf,
+        const std::unordered_map<std::string, relay_config> &vlans) {
+    if (vrf.empty()) {
+        return;
+    }
+    auto sit = g_server_vrf_socks.find(vrf);
+    if (sit == g_server_vrf_socks.end()) {
+        return;
+    }
+    for (const auto &entry : vlans) {
+        if (entry.second.server_vrf == vrf) {
+            return;  // still referenced by a live vlan
+        }
+    }
+    if (sit->second.event != nullptr) {
+        event_del(sit->second.event);
+        event_free(sit->second.event);
+    }
+    if (sit->second.sock >= 0) {
+        close(sit->second.sock);
+    }
+    g_server_vrf_socks.erase(sit);
+    syslog(LOG_INFO, "Removed shared upstream socket for server VRF %s\n", vrf.c_str());
 }
 
 /**
@@ -1476,7 +1684,14 @@ void lla_check_callback(evutil_socket_t fd, short event, void *arg) {
             sockets.push_back(gua_sock);
             sockets.push_back(lla_sock);
             prepare_relay_config(vlan.second, gua_sock, filter);
-            if (!dual_tor_sock) {
+            if (!vlan.second.server_vrf.empty()) {
+                // Servers live in a different VRF: relay-reply arrives on the
+                // shared per-VRF socket (armed once, demuxed by link-address), so
+                // do not also listen on this vlan's gua socket.
+                if (get_or_create_server_vrf_sock(vlan.second.server_vrf, vlans) < 0) {
+                    syslog(LOG_ERR, "libevent: Failed to arm server VRF socket for %s\n", vlan.first.c_str());
+                }
+            } else if (!dual_tor_sock) {
 	            vlan.second.server_event = event_new(base, gua_sock, EV_READ|EV_PERSIST,
                                        server_callback, &(vlan.second));
                 if (vlan.second.server_event == NULL) {
@@ -1559,8 +1774,10 @@ bool apply_desired_config(std::unordered_map<std::string, relay_config> &vlans,
     for (auto it = vlans.begin(); it != vlans.end(); ) {
         if (desired.find(it->first) == desired.end()) {
             syslog(LOG_INFO, "Remove relay config for %s at runtime\n", it->first.c_str());
+            std::string removed_server_vrf = it->second.server_vrf;
             teardown_vlan_relay(it->second);
             it = vlans.erase(it);
+            release_server_vrf_sock_if_unused(removed_server_vrf, vlans);
         } else {
             ++it;
         }
@@ -1577,6 +1794,8 @@ bool apply_desired_config(std::unordered_map<std::string, relay_config> &vlans,
             ncfg.servers = dcfg.servers;
             ncfg.is_option_79 = dcfg.is_option_79;
             ncfg.is_interface_id = dcfg.is_interface_id;
+            ncfg.vrf = dcfg.vrf;
+            ncfg.server_vrf = dcfg.server_vrf;
             ncfg.mux_key = "";
             ncfg.state_db = nullptr;
             ncfg.is_lla_ready = false;
@@ -1586,18 +1805,39 @@ bool apply_desired_config(std::unordered_map<std::string, relay_config> &vlans,
             syslog(LOG_INFO, "Add relay config for %s at runtime\n", name.c_str());
         } else {
             relay_config &live = it->second;
+            bool vrf_changed = (live.vrf != dcfg.vrf) || (live.server_vrf != dcfg.server_vrf);
             bool changed = (live.servers != dcfg.servers) ||
                            (live.is_option_79 != dcfg.is_option_79) ||
-                           (live.is_interface_id != dcfg.is_interface_id);
+                           (live.is_interface_id != dcfg.is_interface_id) ||
+                           vrf_changed;
             if (changed) {
                 live.servers = dcfg.servers;
                 live.is_option_79 = dcfg.is_option_79;
                 live.is_interface_id = dcfg.is_interface_id;
-                // Rebuild the cached server sockaddr list only when the relay
-                // for this vlan is already active; otherwise lla_check_callback
-                // builds it when the interface becomes ready.
-                if (live.is_lla_ready) {
-                    build_servers_sock(live);
+                if (vrf_changed && live.is_lla_ready) {
+                    // The upstream socket is bound to the old VRF via
+                    // SO_BINDTODEVICE and cannot be rebound in place. Tear the
+                    // relay down and reset readiness so the link-local arming
+                    // path recreates the sockets under the new VRF.
+                    syslog(LOG_INFO, "VRF for %s changed (vrf '%s'->'%s', server_vrf '%s'->'%s') at runtime; rebinding upstream socket\n",
+                           name.c_str(), live.vrf.c_str(), dcfg.vrf.c_str(),
+                           live.server_vrf.c_str(), dcfg.server_vrf.c_str());
+                    std::string prev_server_vrf = live.server_vrf;
+                    teardown_vlan_relay(live);
+                    live.is_lla_ready = false;
+                    live.vrf = dcfg.vrf;
+                    live.server_vrf = dcfg.server_vrf;
+                    added = true;
+                    release_server_vrf_sock_if_unused(prev_server_vrf, vlans);
+                } else {
+                    live.vrf = dcfg.vrf;
+                    live.server_vrf = dcfg.server_vrf;
+                    // Rebuild the cached server sockaddr list only when the relay
+                    // for this vlan is already active; otherwise lla_check_callback
+                    // builds it when the interface becomes ready.
+                    if (live.is_lla_ready) {
+                        build_servers_sock(live);
+                    }
                 }
                 syslog(LOG_INFO, "Update relay config for %s at runtime\n", name.c_str());
             }

--- a/dhcp6relay/src/relay.cpp
+++ b/dhcp6relay/src/relay.cpp
@@ -2,6 +2,7 @@
 #include <unistd.h>
 #include <event.h>
 #include <sstream>
+#include <chrono>
 #include <event2/event.h>
 #include <event2/bufferevent.h>
 #include <signal.h>
@@ -19,6 +20,35 @@ static std::string counter_table = "DHCPv6_COUNTER_TABLE|";
 
 static uint8_t client_recv_buffer[BUFFER_SIZE];
 static uint8_t server_recv_buffer[BUFFER_SIZE];
+
+/**
+ * @code                bool should_log_throttled(const std::string &key);
+ *
+ * @brief               rate-limit a per-packet log so it cannot flood syslog.
+ *                      Each key is logged at most once per LOG_THROTTLE_INTERVAL.
+ *                      Used for warnings that can fire per packet, e.g. client
+ *                      traffic on an unconfigured interface (expected before any
+ *                      DHCP_RELAY config now that dhcp6relay starts always).
+ *
+ * @param key           identifier of the throttled log site (e.g. interface or
+ *                      vlan name)
+ *
+ * @return              true if the caller should emit the log now
+ *
+ * @note                Called only from the libevent main thread, so the static
+ *                      bookkeeping needs no locking.
+ */
+static bool should_log_throttled(const std::string &key) {
+    static std::unordered_map<std::string, std::chrono::steady_clock::time_point> last_logged;
+    constexpr auto LOG_THROTTLE_INTERVAL = std::chrono::seconds(60);
+    auto now = std::chrono::steady_clock::now();
+    auto it = last_logged.find(key);
+    if (it == last_logged.end() || (now - it->second) >= LOG_THROTTLE_INTERVAL) {
+        last_logged[key] = now;
+        return true;
+    }
+    return false;
+}
 
 /* DHCPv6 filter */
 /* sudo tcpdump -dd "inbound and ip6 dst ff02::1:2 && udp dst port 547" */
@@ -455,6 +485,31 @@ int sock_open(const struct sock_fprog *fprog)
 }
 
 /**
+ * @code                        build_servers_sock(relay_config &config);
+ *
+ * @brief                       (re)build the cached server sockaddr list from config.servers
+ *
+ * @param config                relay interface config whose servers_sock is rebuilt
+ *
+ * @return                      none
+ */
+void build_servers_sock(relay_config &config) {
+    config.servers_sock.clear();
+    for(auto server: config.servers) {
+        sockaddr_in6 tmp;
+        if(inet_pton(AF_INET6, server.c_str(), &tmp.sin6_addr) != 1)
+        {
+            syslog(LOG_WARNING, "inet_pton: Failed to convert IPv6 address\n");
+        }
+        tmp.sin6_family = AF_INET6;
+        tmp.sin6_flowinfo = 0;
+        tmp.sin6_port = htons(RELAY_PORT);
+        tmp.sin6_scope_id = 0;
+        config.servers_sock.push_back(tmp);
+    }
+}
+
+/**
  * @code                        prepare_relay_config(relay_config &interface_config, int gua_sock, int filter);
  * 
  * @brief                       prepare for specified relay interface config: server and link address
@@ -473,18 +528,7 @@ void prepare_relay_config(relay_config &interface_config, int gua_sock, int filt
     interface_config.gua_sock = gua_sock;
     interface_config.filter = filter; 
 
-    for(auto server: interface_config.servers) {
-        sockaddr_in6 tmp;
-        if(inet_pton(AF_INET6, server.c_str(), &tmp.sin6_addr) != 1)
-        {
-            syslog(LOG_WARNING, "inet_pton: Failed to convert IPv6 address\n");
-        }
-        tmp.sin6_family = AF_INET6;
-        tmp.sin6_flowinfo = 0;
-        tmp.sin6_port = htons(RELAY_PORT);
-        tmp.sin6_scope_id = 0; 
-        interface_config.servers_sock.push_back(tmp);
-    }
+    build_servers_sock(interface_config);
 
     if (getifaddrs(&ifa) == -1) {
         syslog(LOG_WARNING, "getifaddrs: Unable to get network interfaces\n");
@@ -899,14 +943,17 @@ void client_callback(evutil_socket_t fd, short event, void *arg) {
         // add is_lla_ready flag check in this callback func
         auto vlan = vlan_map.find(intf);
         if (vlan == vlan_map.end()) {
-            if (intf.find(CLIENT_IF_PREFIX) != std::string::npos) {
+            if (intf.find(CLIENT_IF_PREFIX) != std::string::npos &&
+                should_log_throttled("invalid_intf:" + intf)) {
                 syslog(LOG_WARNING, "Invalid input interface %s\n", interfaceName);
             }
             continue;
         }
         auto config_itr = vlans->find(vlan->second);
         if (config_itr == vlans->end()) {
-            syslog(LOG_WARNING, "Config not found for vlan %s\n", vlan->second.c_str());
+            if (should_log_throttled("no_config:" + vlan->second)) {
+                syslog(LOG_WARNING, "Config not found for vlan %s\n", vlan->second.c_str());
+            }
             continue;
         }
         auto config = config_itr->second;
@@ -1309,6 +1356,26 @@ void loop_relay(std::unordered_map<std::string, relay_config> &vlans) {
     // hence manually invoke it here to immediate execute it
     lla_check_callback(-1, 0, timer_args);
 
+    // Set up the runtime configuration monitor so relay configuration changes
+    // are applied without restarting the container. The monitor thread watches
+    // CONFIG_DB and wakes this libevent loop through a self-pipe.
+    int cfg_pipe[2];
+    if (pipe(cfg_pipe) == 0) {
+        evutil_make_socket_nonblocking(cfg_pipe[0]);
+        evutil_make_socket_nonblocking(cfg_pipe[1]);
+        auto *apply_ctx = new config_apply_ctx{&vlans, timer_args, timer_event, cfg_pipe[0]};
+        auto cfg_event = event_new(base, cfg_pipe[0], EV_READ|EV_PERSIST, config_change_callback, apply_ctx);
+        if (cfg_event != NULL) {
+            event_add(cfg_event, NULL);
+            start_dhcp_config_monitor(cfg_pipe[1]);
+            syslog(LOG_INFO, "libevent: Add runtime config monitor event\n");
+        } else {
+            syslog(LOG_ERR, "libevent: Failed to create runtime config monitor event\n");
+        }
+    } else {
+        syslog(LOG_ERR, "Failed to create config monitor pipe: %s\n", strerror(errno));
+    }
+
     if(signal_init() == 0 && signal_start() == 0) {
         shutdown_relay();
         for(std::size_t i = 0; i < sockets.size(); i++) {
@@ -1323,6 +1390,7 @@ void loop_relay(std::unordered_map<std::string, relay_config> &vlans) {
  * @brief free signals and terminate threads
  */
 void shutdown_relay() {
+    stop_dhcp_config_monitor();
     event_del(ev_sigint);
     event_del(ev_sigterm);
     event_free(ev_sigint);
@@ -1409,13 +1477,14 @@ void lla_check_callback(evutil_socket_t fd, short event, void *arg) {
             sockets.push_back(lla_sock);
             prepare_relay_config(vlan.second, gua_sock, filter);
             if (!dual_tor_sock) {
-	            auto server_callback_event = event_new(base, gua_sock, EV_READ|EV_PERSIST,
+	            vlan.second.server_event = event_new(base, gua_sock, EV_READ|EV_PERSIST,
                                        server_callback, &(vlan.second));
-                if (server_callback_event == NULL) {
+                if (vlan.second.server_event == NULL) {
                     syslog(LOG_ERR, "libevent: Failed to create server listen libevent\n");
+                } else {
+                    event_add(vlan.second.server_event, NULL);
+                    syslog(LOG_INFO, "libevent: add server listen socket for %s\n", vlan.first.c_str());
                 }
-                event_add(server_callback_event, NULL);
-                syslog(LOG_INFO, "libevent: add server listen socket for %s\n", vlan.first.c_str());
             }
         } else {
             syslog(LOG_ERR, "Failed to create dualtor loopback listen socket");
@@ -1425,5 +1494,165 @@ void lla_check_callback(evutil_socket_t fd, short event, void *arg) {
     if (all_llas_are_ready) {
         syslog(LOG_INFO, "All Vlans' lla are ready, terminate check timer");
         event_del(timer_event);
+    }
+}
+
+/**
+ * @code                void teardown_vlan_relay(relay_config &config);
+ *
+ * @brief               free libevent event and sockets for a vlan being removed at runtime
+ *
+ * @param config        relay interface config being torn down
+ *
+ * @return              none
+ */
+void teardown_vlan_relay(relay_config &config) {
+    if (config.server_event != nullptr) {
+        event_del(config.server_event);
+        event_free(config.server_event);
+        config.server_event = nullptr;
+    }
+    if (config.is_lla_ready) {
+        if (config.gua_sock > 0) {
+            close(config.gua_sock);
+            config.gua_sock = -1;
+        }
+        if (config.lla_sock > 0) {
+            close(config.lla_sock);
+            config.lla_sock = -1;
+        }
+    }
+    // Remove this vlan's entries from the global lookup maps so stale packets
+    // are not associated with a torn-down relay.
+    for (auto it = vlan_map.begin(); it != vlan_map.end(); ) {
+        if (it->second == config.interface) {
+            it = vlan_map.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    for (auto it = addr_vlan_map.begin(); it != addr_vlan_map.end(); ) {
+        if (it->second == config.interface) {
+            it = addr_vlan_map.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+/**
+ * @code                bool apply_desired_config(std::unordered_map<std::string, relay_config> &vlans,
+ *                                                std::unordered_map<std::string, relay_config> &desired);
+ *
+ * @brief               reconcile the live vlans map with the desired config (add/remove/update)
+ *
+ * @param vlans         live per-vlan relay config (mutated in place)
+ * @param desired       desired per-vlan relay config (config fields only)
+ *
+ * @return              true if at least one vlan was newly added (sockets need arming)
+ */
+bool apply_desired_config(std::unordered_map<std::string, relay_config> &vlans,
+                          std::unordered_map<std::string, relay_config> &desired) {
+    bool added = false;
+
+    // Remove relay configs for vlans no longer present in the desired config.
+    for (auto it = vlans.begin(); it != vlans.end(); ) {
+        if (desired.find(it->first) == desired.end()) {
+            syslog(LOG_INFO, "Remove relay config for %s at runtime\n", it->first.c_str());
+            teardown_vlan_relay(it->second);
+            it = vlans.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    // Add new vlans and update existing ones.
+    for (auto &desired_entry : desired) {
+        const std::string &name = desired_entry.first;
+        relay_config &dcfg = desired_entry.second;
+        auto it = vlans.find(name);
+        if (it == vlans.end()) {
+            relay_config ncfg;
+            ncfg.interface = name;
+            ncfg.servers = dcfg.servers;
+            ncfg.is_option_79 = dcfg.is_option_79;
+            ncfg.is_interface_id = dcfg.is_interface_id;
+            ncfg.mux_key = "";
+            ncfg.state_db = nullptr;
+            ncfg.is_lla_ready = false;
+            ncfg.server_event = nullptr;
+            vlans[name] = ncfg;
+            added = true;
+            syslog(LOG_INFO, "Add relay config for %s at runtime\n", name.c_str());
+        } else {
+            relay_config &live = it->second;
+            bool changed = (live.servers != dcfg.servers) ||
+                           (live.is_option_79 != dcfg.is_option_79) ||
+                           (live.is_interface_id != dcfg.is_interface_id);
+            if (changed) {
+                live.servers = dcfg.servers;
+                live.is_option_79 = dcfg.is_option_79;
+                live.is_interface_id = dcfg.is_interface_id;
+                // Rebuild the cached server sockaddr list only when the relay
+                // for this vlan is already active; otherwise lla_check_callback
+                // builds it when the interface becomes ready.
+                if (live.is_lla_ready) {
+                    build_servers_sock(live);
+                }
+                syslog(LOG_INFO, "Update relay config for %s at runtime\n", name.c_str());
+            }
+        }
+    }
+
+    return added;
+}
+
+/**
+ * @code                void config_change_callback(evutil_socket_t fd, short event, void *arg);
+ *
+ * @brief               libevent callback that applies runtime relay configuration changes
+ *
+ * @param fd            notify pipe read end
+ * @param event         libevent triggered event
+ * @param arg           pointer to config_apply_ctx
+ *
+ * @return              none
+ */
+void config_change_callback(evutil_socket_t fd, short event, void *arg) {
+    auto *ctx = reinterpret_cast<config_apply_ctx *>(arg);
+
+    // Drain the notify pipe; the monitor thread may have coalesced several
+    // changes into one or more wake bytes.
+    char drain_buf[64];
+    while (read(ctx->notify_rd, drain_buf, sizeof(drain_buf)) > 0) {
+        // discard
+    }
+
+    std::unordered_map<std::string, relay_config> desired;
+    if (!fetch_desired_config(desired)) {
+        return;
+    }
+
+    bool added = apply_desired_config(*ctx->vlans, desired);
+
+    // A vlan's sockets are armed once its interface link-local address is ready,
+    // which happens when a vlan is added or when its interface later becomes
+    // ready (a STATE_DB INTERFACE_TABLE change). Such vlans still have
+    // is_lla_ready == false; re-fire the link-local check so the existing arming
+    // path picks them up now instead of at the next periodic 60s tick.
+    bool pending_lla = false;
+    for (const auto &vlan : *ctx->vlans) {
+        if (!vlan.second.is_lla_ready) {
+            pending_lla = true;
+            break;
+        }
+    }
+
+    if (added || pending_lla) {
+        struct timeval tv;
+        evutil_timerclear(&tv);
+        tv.tv_sec = 60;
+        event_add(ctx->timer_event, &tv);
+        lla_check_callback(-1, 0, ctx->timer_args);
     }
 }

--- a/dhcp6relay/src/relay.cpp
+++ b/dhcp6relay/src/relay.cpp
@@ -662,11 +662,7 @@ int prepare_vlan_sockets(int &gua_sock, int &lla_sock, relay_config &config) {
     evutil_make_listen_socket_reuseable(lla_sock);
     evutil_make_socket_nonblocking(lla_sock);
 
-    // Bind the upstream (gua) socket to the configured VRF so relay-forward
-    // messages to the DHCPv6 servers egress in that VRF's routing table. A
-    // non-default VRF requires SO_BINDTODEVICE to the VRF master device; the
-    // default (global) table needs no binding. The client-facing lla socket is
-    // link-scoped and stays on the vlan interface.
+    // Bind the upstream (gua) socket to the VRF via SO_BINDTODEVICE so relay-forward egresses there; the default table needs no binding.
     if (!config.vrf.empty() && config.vrf != DEFAULT_VRF) {
         if (setsockopt(gua_sock, SOL_SOCKET, SO_BINDTODEVICE,
                        config.vrf.c_str(), config.vrf.size()) < 0) {
@@ -800,8 +796,7 @@ void relay_client(const uint8_t *msg, uint16_t len, const ip6_hdr *ip_hdr, const
     if (dual_tor_sock) {
         sock = config->lo_sock;
     }
-    // Servers in an explicit (different) VRF are reached over the shared per-VRF
-    // socket so relay-forward egresses in that VRF and the reply returns on it.
+    // Servers in an explicit VRF use the shared per-VRF socket so relay-forward egresses there and the reply returns on it.
     if (!config->server_vrf.empty()) {
         int vrf_sock = lookup_server_vrf_sock(config->server_vrf);
         if (vrf_sock < 0) {
@@ -872,8 +867,7 @@ void relay_relay_forw(const uint8_t *msg, int32_t len, const ip6_hdr *ip_hdr, re
     if (dual_tor_sock) {
         sock = config->lo_sock;
     }
-    // Servers in an explicit (different) VRF are reached over the shared per-VRF
-    // socket so relay-forward egresses in that VRF and the reply returns on it.
+    // Servers in an explicit VRF use the shared per-VRF socket so relay-forward egresses there and the reply returns on it.
     if (!config->server_vrf.empty()) {
         int vrf_sock = lookup_server_vrf_sock(config->server_vrf);
         if (vrf_sock < 0) {
@@ -1564,9 +1558,7 @@ void loop_relay(std::unordered_map<std::string, relay_config> &vlans) {
     // hence manually invoke it here to immediate execute it
     lla_check_callback(-1, 0, timer_args);
 
-    // Set up the runtime configuration monitor so relay configuration changes
-    // are applied without restarting the container. The monitor thread watches
-    // CONFIG_DB and wakes this libevent loop through a self-pipe.
+    // Runtime config monitor: apply relay config changes without a container restart (wakes this loop via a self-pipe).
     int cfg_pipe[2];
     if (pipe(cfg_pipe) == 0) {
         evutil_make_socket_nonblocking(cfg_pipe[0]);
@@ -1685,9 +1677,7 @@ void lla_check_callback(evutil_socket_t fd, short event, void *arg) {
             sockets.push_back(lla_sock);
             prepare_relay_config(vlan.second, gua_sock, filter);
             if (!vlan.second.server_vrf.empty()) {
-                // Servers live in a different VRF: relay-reply arrives on the
-                // shared per-VRF socket (armed once, demuxed by link-address), so
-                // do not also listen on this vlan's gua socket.
+                // Servers in a different VRF: replies arrive on the shared per-VRF socket, so don't also listen on this vlan's gua socket.
                 if (get_or_create_server_vrf_sock(vlan.second.server_vrf, vlans) < 0) {
                     syslog(LOG_ERR, "libevent: Failed to arm server VRF socket for %s\n", vlan.first.c_str());
                 }
@@ -1737,8 +1727,7 @@ void teardown_vlan_relay(relay_config &config) {
             config.lla_sock = -1;
         }
     }
-    // Remove this vlan's entries from the global lookup maps so stale packets
-    // are not associated with a torn-down relay.
+    // Remove this vlan's entries from the global lookup maps to avoid stale packet associations.
     for (auto it = vlan_map.begin(); it != vlan_map.end(); ) {
         if (it->second == config.interface) {
             it = vlan_map.erase(it);
@@ -1815,10 +1804,7 @@ bool apply_desired_config(std::unordered_map<std::string, relay_config> &vlans,
                 live.is_option_79 = dcfg.is_option_79;
                 live.is_interface_id = dcfg.is_interface_id;
                 if (vrf_changed && live.is_lla_ready) {
-                    // The upstream socket is bound to the old VRF via
-                    // SO_BINDTODEVICE and cannot be rebound in place. Tear the
-                    // relay down and reset readiness so the link-local arming
-                    // path recreates the sockets under the new VRF.
+                    // SO_BINDTODEVICE can't be rebound in place: tear down and reset readiness so the arming path recreates sockets under the new VRF.
                     syslog(LOG_INFO, "VRF for %s changed (vrf '%s'->'%s', server_vrf '%s'->'%s') at runtime; rebinding upstream socket\n",
                            name.c_str(), live.vrf.c_str(), dcfg.vrf.c_str(),
                            live.server_vrf.c_str(), dcfg.server_vrf.c_str());
@@ -1861,8 +1847,7 @@ bool apply_desired_config(std::unordered_map<std::string, relay_config> &vlans,
 void config_change_callback(evutil_socket_t fd, short event, void *arg) {
     auto *ctx = reinterpret_cast<config_apply_ctx *>(arg);
 
-    // Drain the notify pipe; the monitor thread may have coalesced several
-    // changes into one or more wake bytes.
+    // Drain the notify pipe (the monitor may have coalesced several changes into wake bytes).
     char drain_buf[64];
     while (read(ctx->notify_rd, drain_buf, sizeof(drain_buf)) > 0) {
         // discard
@@ -1875,11 +1860,7 @@ void config_change_callback(evutil_socket_t fd, short event, void *arg) {
 
     bool added = apply_desired_config(*ctx->vlans, desired);
 
-    // A vlan's sockets are armed once its interface link-local address is ready,
-    // which happens when a vlan is added or when its interface later becomes
-    // ready (a STATE_DB INTERFACE_TABLE change). Such vlans still have
-    // is_lla_ready == false; re-fire the link-local check so the existing arming
-    // path picks them up now instead of at the next periodic 60s tick.
+    // Re-fire the link-local check so newly-ready vlans (is_lla_ready == false) get armed now, not at the next 60s tick.
     bool pending_lla = false;
     for (const auto &vlan : *ctx->vlans) {
         if (!vlan.second.is_lla_ready) {

--- a/dhcp6relay/src/relay.h
+++ b/dhcp6relay/src/relay.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <unordered_map>
 #include <event2/util.h>
 #include <syslog.h>
 #include "dbconnector.h"
@@ -77,6 +78,7 @@ struct relay_config {
     std::shared_ptr<swss::Table> mux_table;
     std::shared_ptr<swss::DBConnector> config_db;
     bool is_lla_ready;
+    struct event *server_event = nullptr;
 };
 
 /* DHCPv6 messages and options */
@@ -283,6 +285,67 @@ void server_callback_dualtor(evutil_socket_t fd, short event, void *arg);
  * @param state_db      state_db connector
  */
 void loop_relay(std::unordered_map<std::string, relay_config> &vlans);
+
+/*
+ * Context passed to config_change_callback so the libevent main thread can
+ * reconcile the live vlans map with the desired configuration published by the
+ * runtime configuration monitor thread.
+ */
+struct config_apply_ctx {
+    std::unordered_map<std::string, relay_config> *vlans;
+    void *timer_args;
+    struct event *timer_event;
+    int notify_rd;
+};
+
+/**
+ * @code                build_servers_sock(relay_config &config);
+ *
+ * @brief               (re)build the cached server sockaddr list from config.servers
+ *
+ * @param config        relay interface config whose servers_sock is rebuilt
+ *
+ * @return              none
+ */
+void build_servers_sock(relay_config &config);
+
+/**
+ * @code                teardown_vlan_relay(relay_config &config);
+ *
+ * @brief               free libevent event and sockets for a vlan being removed at runtime
+ *
+ * @param config        relay interface config being torn down
+ *
+ * @return              none
+ */
+void teardown_vlan_relay(relay_config &config);
+
+/**
+ * @code                apply_desired_config(std::unordered_map<std::string, relay_config> &vlans,
+ *                                          std::unordered_map<std::string, relay_config> &desired);
+ *
+ * @brief               reconcile the live vlans map with the desired config (add/remove/update)
+ *
+ * @param vlans         live per-vlan relay config (mutated in place)
+ * @param desired        desired per-vlan relay config (config fields only)
+ *
+ * @return              true if at least one vlan was newly added (sockets need arming)
+ */
+bool apply_desired_config(std::unordered_map<std::string, relay_config> &vlans,
+                          std::unordered_map<std::string, relay_config> &desired);
+
+/**
+ * @code                config_change_callback(evutil_socket_t fd, short event, void *arg);
+ *
+ * @brief               libevent callback that applies runtime relay configuration changes
+ *
+ * @param fd            notify pipe read end
+ * @param event         libevent triggered event
+ * @param arg           pointer to config_apply_ctx
+ *
+ * @return              none
+ */
+void config_change_callback(evutil_socket_t fd, short event, void *arg);
 
 /**
  * @code signal_init();

--- a/dhcp6relay/src/relay.h
+++ b/dhcp6relay/src/relay.h
@@ -29,6 +29,14 @@
 #define CLIENT_IF_PREFIX "Ethernet"
 #define BUFFER_SIZE 9200
 
+/* CONFIG_DB field names used to resolve the VRF the upstream socket binds to.
+ * The VLAN's own VRF comes from VLAN_INTERFACE|<vlan> "vrf_name"; an explicit
+ * server-side VRF (server reachable in a different VRF) comes from
+ * DHCP_RELAY|<vlan> "server_vrf". A value of DEFAULT_VRF means the global table. */
+#define VRF_NAME_FIELD "vrf_name"
+#define SERVER_VRF_FIELD "server_vrf"
+#define DEFAULT_VRF "default"
+
 #define lengthof(A) (sizeof (A) / sizeof (A)[0])
 
 #define OPTION_RELAY_MSG 9
@@ -78,6 +86,16 @@ struct relay_config {
     std::shared_ptr<swss::Table> mux_table;
     std::shared_ptr<swss::DBConnector> config_db;
     bool is_lla_ready;
+    /* VRF the upstream (gua) socket binds to via SO_BINDTODEVICE: the VLAN's own
+     * vrf_name, or DEFAULT_VRF for the global table. Used to reach servers that
+     * are reachable in the same VRF as the client VLAN (the common case). */
+    std::string vrf;
+    /* Explicit VRF in which the DHCPv6 servers are reachable, when that differs
+     * from the VLAN's own VRF. Empty means "same VRF as the VLAN" (use gua_sock).
+     * When set, relay-forward is sent and relay-reply received on a shared
+     * per-VRF socket bound in6addr_any:547 + SO_BINDTODEVICE(server_vrf), with
+     * replies demultiplexed to the VLAN by the relay link-address. */
+    std::string server_vrf;
     struct event *server_event = nullptr;
 };
 
@@ -297,6 +315,36 @@ struct config_apply_ctx {
     struct event *timer_event;
     int notify_rd;
 };
+
+/* Shared upstream socket bound (SO_BINDTODEVICE) to a server VRF: one socket is
+ * shared by all vlans whose DHCP_RELAY row names that server_vrf. Declared here
+ * (rather than file-static in relay.cpp) so the unit tests can drive and observe
+ * the create/lookup/release lifecycle. */
+struct server_vrf_socket {
+    int sock;
+    struct event *event;
+};
+extern std::map<std::string, server_vrf_socket> g_server_vrf_socks;
+
+/* Return the shared upstream socket fd for `vrf`, or -1 if it is not armed. */
+int lookup_server_vrf_sock(const std::string &vrf);
+
+/**
+ * @code                release_server_vrf_sock_if_unused(const std::string &vrf, vlans);
+ *
+ * @brief               close and drop the shared upstream socket for `vrf` once
+ *                      no live vlan still references it as its server_vrf, so a
+ *                      deleted/recreated server VRF cannot leave a stale
+ *                      SO_BINDTODEVICE socket behind.
+ *
+ * @param vrf           server VRF whose socket may now be unreferenced
+ * @param vlans         live per-vlan relay config
+ *
+ * @return              none
+ */
+void release_server_vrf_sock_if_unused(
+        const std::string &vrf,
+        const std::unordered_map<std::string, relay_config> &vlans);
 
 /**
  * @code                build_servers_sock(relay_config &config);

--- a/dhcp6relay/test/mock_config_interface.cpp
+++ b/dhcp6relay/test/mock_config_interface.cpp
@@ -1,3 +1,6 @@
+#include <chrono>
+#include <thread>
+#include <unistd.h>
 #include "mock_config_interface.h"
 
 using namespace ::testing;
@@ -25,12 +28,12 @@ TEST(configInterface, get_dhcp) {
   swss::SubscriberStateTable ipHelpersTable(config_db.get(), "DHCP_RELAY");
   std::unordered_map<std::string, relay_config> vlans;
 
-  ASSERT_NO_THROW(get_dhcp(vlans, &ipHelpersTable, false, config_db));
+  ASSERT_NO_THROW(get_dhcp(vlans, &ipHelpersTable, config_db));
   EXPECT_EQ(vlans.size(), 0);
 
   swssSelect.addSelectable(&ipHelpersTable);
 
-  ASSERT_NO_THROW(get_dhcp(vlans, &ipHelpersTable, false, config_db));
+  ASSERT_NO_THROW(get_dhcp(vlans, &ipHelpersTable, config_db));
   EXPECT_EQ(vlans.size(), 1);
 }
 
@@ -69,4 +72,138 @@ TEST(configInterface, stopSwssNotificationPoll) {
 
 TEST(configInterface, check_is_lla_ready) {
   EXPECT_FALSE(check_is_lla_ready("Vlan1000"));
+}
+
+TEST(configInterface, build_desired_config) {
+  std::shared_ptr<swss::DBConnector> config_db = std::make_shared<swss::DBConnector> ("CONFIG_DB", 0);
+  config_db->hset("DHCP_RELAY|Vlan2000", "dhcpv6_servers@", "fc02:2000::1,fc02:2000::2");
+  config_db->hset("DHCP_RELAY|Vlan2000", "dhcpv6_option|rfc6939_support", "false");
+  config_db->hset("DHCP_RELAY|Vlan2000", "dhcpv6_option|interface_id", "true");
+  config_db->hset("VLAN_INTERFACE|Vlan2000|fc02:2000::1", "", "");
+
+  auto desired = build_desired_config(config_db);
+  ASSERT_EQ(desired.count("Vlan2000"), 1);
+  EXPECT_EQ(desired["Vlan2000"].servers.size(), 2);
+  EXPECT_FALSE(desired["Vlan2000"].is_option_79);
+  EXPECT_TRUE(desired["Vlan2000"].is_interface_id);
+}
+
+TEST(configInterface, build_desired_config_skips_vlan_without_ipv6) {
+  std::shared_ptr<swss::DBConnector> config_db = std::make_shared<swss::DBConnector> ("CONFIG_DB", 0);
+  // No VLAN_INTERFACE IPv6 address for Vlan3000, so it must not be relayed.
+  config_db->hset("DHCP_RELAY|Vlan3000", "dhcpv6_servers@", "fc02:3000::1");
+
+  auto desired = build_desired_config(config_db);
+  EXPECT_EQ(desired.count("Vlan3000"), 0);
+}
+
+TEST(configInterface, build_desired_config_interface_id_default_tracks_dualtor) {
+  // The interface-id option defaults to enabled in Dual-ToR mode and disabled
+  // otherwise. build_desired_config (used by the runtime config monitor) must
+  // honour this default for a VLAN whose DHCP_RELAY entry does not set
+  // dhcpv6_option|interface_id explicitly, in both Dual-ToR and non-Dual-ToR
+  // mode. dual_tor_sock is fixed at startup from the -u option.
+  std::shared_ptr<swss::DBConnector> config_db = std::make_shared<swss::DBConnector> ("CONFIG_DB", 0);
+  config_db->hset("DHCP_RELAY|Vlan4200", "dhcpv6_servers@", "fc02:4200::1");
+  config_db->hset("VLAN_INTERFACE|Vlan4200|fc02:4200::1", "", "");
+
+  bool saved_dual_tor_sock = dual_tor_sock;
+
+  // Non-Dual-ToR: interface-id default is disabled.
+  dual_tor_sock = false;
+  auto desired_non_dualtor = build_desired_config(config_db);
+  ASSERT_EQ(desired_non_dualtor.count("Vlan4200"), 1);
+  EXPECT_FALSE(desired_non_dualtor["Vlan4200"].is_interface_id);
+
+  // Dual-ToR: interface-id default is enabled.
+  dual_tor_sock = true;
+  auto desired_dualtor = build_desired_config(config_db);
+  ASSERT_EQ(desired_dualtor.count("Vlan4200"), 1);
+  EXPECT_TRUE(desired_dualtor["Vlan4200"].is_interface_id);
+
+  // Restore the global so the mode does not leak into other tests.
+  dual_tor_sock = saved_dual_tor_sock;
+
+  config_db->del("DHCP_RELAY|Vlan4200");
+  config_db->del("VLAN_INTERFACE|Vlan4200|fc02:4200::1");
+}
+
+TEST(configInterface, fetch_desired_config) {
+  std::unordered_map<std::string, relay_config> out;
+  EXPECT_TRUE(fetch_desired_config(out));
+}
+
+TEST(configInterface, start_stop_dhcp_config_monitor) {
+  std::shared_ptr<swss::DBConnector> config_db = std::make_shared<swss::DBConnector> ("CONFIG_DB", 0);
+  config_db->hset("DHCP_RELAY|Vlan4000", "dhcpv6_servers@", "fc02:4000::1");
+  config_db->hset("VLAN_INTERFACE|Vlan4000|fc02:4000::1", "", "");
+
+  int pipefd[2];
+  ASSERT_EQ(pipe(pipefd), 0);
+
+  // Start the monitor thread; it reads CONFIG_DB, publishes the desired config
+  // and wakes the (read end of the) notify pipe.
+  ASSERT_NO_THROW(start_dhcp_config_monitor(pipefd[1]));
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+  std::unordered_map<std::string, relay_config> out;
+  EXPECT_TRUE(fetch_desired_config(out));
+
+  // Stop the monitor and give the select loop time to observe the stop flag.
+  ASSERT_NO_THROW(stop_dhcp_config_monitor());
+  std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+
+  close(pipefd[0]);
+  close(pipefd[1]);
+}
+
+TEST(configInterface, config_monitor_reacts_to_state_db_interface_table) {
+  // The monitor also watches STATE_DB INTERFACE_TABLE so that a vlan whose
+  // interface becomes ready after startup is reconciled immediately. Drive a
+  // STATE_DB INTERFACE_TABLE change while the monitor runs and confirm the
+  // monitor wakes (the notify pipe receives a byte) and re-publishes the
+  // desired config.
+  std::shared_ptr<swss::DBConnector> config_db = std::make_shared<swss::DBConnector> ("CONFIG_DB", 0);
+  config_db->hset("DHCP_RELAY|Vlan4100", "dhcpv6_servers@", "fc02:4100::1");
+  config_db->hset("VLAN_INTERFACE|Vlan4100|fc02:4100::1", "", "");
+
+  int pipefd[2];
+  ASSERT_EQ(pipe(pipefd), 0);
+  evutil_make_socket_nonblocking(pipefd[0]);
+
+  ASSERT_NO_THROW(start_dhcp_config_monitor(pipefd[1]));
+  // Let the monitor publish its startup snapshot and drain that wake byte.
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  char drain[64];
+  while (read(pipefd[0], drain, sizeof(drain)) > 0) { /* discard startup wake */ }
+
+  // A STATE_DB INTERFACE_TABLE change must wake the monitor's select loop.
+  std::shared_ptr<swss::DBConnector> state_db = std::make_shared<swss::DBConnector> ("STATE_DB", 0);
+  state_db->hset("INTERFACE_TABLE|Vlan4100|fc02:4100::1", "state", "ok");
+
+  // The monitor should re-publish after the STATE_DB change (notify byte). Poll
+  // for up to ~3s to stay robust to scheduling/keyspace-notification latency.
+  ssize_t got = -1;
+  for (int i = 0; i < 30 && got <= 0; ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    got = read(pipefd[0], drain, sizeof(drain));
+  }
+  EXPECT_GT(got, 0);
+
+  // And the latest published desired config still contains the relayed vlan.
+  std::unordered_map<std::string, relay_config> out;
+  EXPECT_TRUE(fetch_desired_config(out));
+  EXPECT_EQ(out.count("Vlan4100"), 1);
+
+  ASSERT_NO_THROW(stop_dhcp_config_monitor());
+  std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+
+  // Clean up the keys this test added so it does not perturb the shared redis
+  // state other tests rely on.
+  config_db->del("DHCP_RELAY|Vlan4100");
+  config_db->del("VLAN_INTERFACE|Vlan4100|fc02:4100::1");
+  state_db->del("INTERFACE_TABLE|Vlan4100|fc02:4100::1");
+
+  close(pipefd[0]);
+  close(pipefd[1]);
 }

--- a/dhcp6relay/test/mock_config_interface.cpp
+++ b/dhcp6relay/test/mock_config_interface.cpp
@@ -128,6 +128,80 @@ TEST(configInterface, build_desired_config_interface_id_default_tracks_dualtor) 
   config_db->del("VLAN_INTERFACE|Vlan4200|fc02:4200::1");
 }
 
+TEST(configInterface, build_desired_config_vrf_from_vlan_interface) {
+  // A VLAN bound to a non-default VRF (VLAN_INTERFACE vrf_name) with no explicit
+  // server_vrf: the upstream socket VRF tracks the VLAN's own vrf_name and there
+  // is no separate server VRF.
+  std::shared_ptr<swss::DBConnector> config_db = std::make_shared<swss::DBConnector> ("CONFIG_DB", 0);
+  config_db->hset("DHCP_RELAY|Vlan5000", "dhcpv6_servers@", "fc02:5000::1");
+  config_db->hset("VLAN_INTERFACE|Vlan5000", "vrf_name", "Vrf-RED");
+  config_db->hset("VLAN_INTERFACE|Vlan5000|fc02:5000::1", "", "");
+
+  auto desired = build_desired_config(config_db);
+  ASSERT_EQ(desired.count("Vlan5000"), 1);
+  EXPECT_EQ(desired["Vlan5000"].vrf, "Vrf-RED");
+  EXPECT_EQ(desired["Vlan5000"].server_vrf, "");
+
+  config_db->del("DHCP_RELAY|Vlan5000");
+  config_db->del("VLAN_INTERFACE|Vlan5000");
+  config_db->del("VLAN_INTERFACE|Vlan5000|fc02:5000::1");
+}
+
+TEST(configInterface, build_desired_config_server_vrf_distinct_from_vlan_vrf) {
+  // An explicit server_vrf different from the VLAN's vrf_name is preserved
+  // separately: the gua socket binds the VLAN VRF and the servers are reached via
+  // the distinct server VRF.
+  std::shared_ptr<swss::DBConnector> config_db = std::make_shared<swss::DBConnector> ("CONFIG_DB", 0);
+  config_db->hset("DHCP_RELAY|Vlan5100", "dhcpv6_servers@", "fc02:5100::1");
+  config_db->hset("DHCP_RELAY|Vlan5100", "server_vrf", "Vrf-BLUE");
+  config_db->hset("VLAN_INTERFACE|Vlan5100", "vrf_name", "Vrf-RED");
+  config_db->hset("VLAN_INTERFACE|Vlan5100|fc02:5100::1", "", "");
+
+  auto desired = build_desired_config(config_db);
+  ASSERT_EQ(desired.count("Vlan5100"), 1);
+  EXPECT_EQ(desired["Vlan5100"].vrf, "Vrf-RED");
+  EXPECT_EQ(desired["Vlan5100"].server_vrf, "Vrf-BLUE");
+
+  config_db->del("DHCP_RELAY|Vlan5100");
+  config_db->del("VLAN_INTERFACE|Vlan5100");
+  config_db->del("VLAN_INTERFACE|Vlan5100|fc02:5100::1");
+}
+
+TEST(configInterface, build_desired_config_server_vrf_same_as_vlan_vrf_is_cleared) {
+  // When server_vrf equals the VLAN's own vrf_name the servers are already
+  // reachable on the gua socket, so server_vrf is cleared (no separate socket).
+  std::shared_ptr<swss::DBConnector> config_db = std::make_shared<swss::DBConnector> ("CONFIG_DB", 0);
+  config_db->hset("DHCP_RELAY|Vlan5150", "dhcpv6_servers@", "fc02:5150::1");
+  config_db->hset("DHCP_RELAY|Vlan5150", "server_vrf", "Vrf-RED");
+  config_db->hset("VLAN_INTERFACE|Vlan5150", "vrf_name", "Vrf-RED");
+  config_db->hset("VLAN_INTERFACE|Vlan5150|fc02:5150::1", "", "");
+
+  auto desired = build_desired_config(config_db);
+  ASSERT_EQ(desired.count("Vlan5150"), 1);
+  EXPECT_EQ(desired["Vlan5150"].vrf, "Vrf-RED");
+  EXPECT_EQ(desired["Vlan5150"].server_vrf, "");
+
+  config_db->del("DHCP_RELAY|Vlan5150");
+  config_db->del("VLAN_INTERFACE|Vlan5150");
+  config_db->del("VLAN_INTERFACE|Vlan5150|fc02:5150::1");
+}
+
+TEST(configInterface, build_desired_config_vrf_defaults_to_global) {
+  // No vrf_name and no server_vrf: the vrf resolves to the global (default) table
+  // and there is no separate server VRF.
+  std::shared_ptr<swss::DBConnector> config_db = std::make_shared<swss::DBConnector> ("CONFIG_DB", 0);
+  config_db->hset("DHCP_RELAY|Vlan5200", "dhcpv6_servers@", "fc02:5200::1");
+  config_db->hset("VLAN_INTERFACE|Vlan5200|fc02:5200::1", "", "");
+
+  auto desired = build_desired_config(config_db);
+  ASSERT_EQ(desired.count("Vlan5200"), 1);
+  EXPECT_EQ(desired["Vlan5200"].vrf, "default");
+  EXPECT_EQ(desired["Vlan5200"].server_vrf, "");
+
+  config_db->del("DHCP_RELAY|Vlan5200");
+  config_db->del("VLAN_INTERFACE|Vlan5200|fc02:5200::1");
+}
+
 TEST(configInterface, fetch_desired_config) {
   std::unordered_map<std::string, relay_config> out;
   EXPECT_TRUE(fetch_desired_config(out));

--- a/dhcp6relay/test/mock_relay.cpp
+++ b/dhcp6relay/test/mock_relay.cpp
@@ -10,6 +10,7 @@
 #include "gmock/gmock.h"
 
 #include "mock_relay.h"
+#include "../src/config_interface.h"
 
 using namespace ::testing;
 
@@ -1161,6 +1162,258 @@ TEST(relay, server_callback_dualtor) {
   //ASSERT_NO_THROW(server_callback_dualtor(0, 0, &vlans_in_loop));
   // normal size and NULL from get_relay_int_from_relay_msg
   ASSERT_NO_THROW(server_callback_dualtor(0, 0, &vlans_in_loop));
+}
+
+TEST(relay, build_servers_sock) {
+  struct relay_config config{};
+  config.interface = "Vlan1000";
+  config.servers.push_back("fc02:2000::1");
+  config.servers.push_back("fc02:2000::2");
+
+  build_servers_sock(config);
+  EXPECT_EQ(config.servers_sock.size(), 2);
+
+  // rebuilding is idempotent: the cached list is cleared then repopulated
+  build_servers_sock(config);
+  EXPECT_EQ(config.servers_sock.size(), 2);
+
+  // shrinking the server list shrinks the cached sockaddr list
+  config.servers.pop_back();
+  build_servers_sock(config);
+  EXPECT_EQ(config.servers_sock.size(), 1);
+}
+
+TEST(relay, teardown_vlan_relay_config_only) {
+  struct relay_config config{};
+  config.interface = "Vlan1000";
+  config.is_lla_ready = false;
+  config.server_event = nullptr;
+
+  vlan_map["Ethernet0"] = "Vlan1000";
+  addr_vlan_map["fc02:1000::1"] = "Vlan1000";
+
+  // A config-only entry (no event, not yet active) tears down cleanly and
+  // clears its entries from the global lookup maps.
+  ASSERT_NO_THROW(teardown_vlan_relay(config));
+  EXPECT_EQ(vlan_map.count("Ethernet0"), 0);
+  EXPECT_EQ(addr_vlan_map.count("fc02:1000::1"), 0);
+}
+
+TEST(relay, apply_desired_config_add_update_remove) {
+  std::unordered_map<std::string, relay_config> vlans;
+  std::unordered_map<std::string, relay_config> desired;
+
+  relay_config d1{};
+  d1.interface = "Vlan1000";
+  d1.servers = {"fc02:2000::1", "fc02:2000::2"};
+  d1.is_option_79 = true;
+  d1.is_interface_id = false;
+  d1.is_lla_ready = false;
+  d1.server_event = nullptr;
+  desired["Vlan1000"] = d1;
+
+  // Add: empty live map gains Vlan1000 and reports that a vlan was added.
+  bool added = apply_desired_config(vlans, desired);
+  EXPECT_TRUE(added);
+  ASSERT_EQ(vlans.count("Vlan1000"), 1);
+  EXPECT_EQ(vlans["Vlan1000"].servers.size(), 2);
+  EXPECT_TRUE(vlans["Vlan1000"].is_option_79);
+  EXPECT_FALSE(vlans["Vlan1000"].is_interface_id);
+
+  // Update: changing servers and options is applied in place with no add.
+  desired["Vlan1000"].servers = {"fc02:2000::9"};
+  desired["Vlan1000"].is_option_79 = false;
+  desired["Vlan1000"].is_interface_id = true;
+  added = apply_desired_config(vlans, desired);
+  EXPECT_FALSE(added);
+  EXPECT_EQ(vlans["Vlan1000"].servers.size(), 1);
+  EXPECT_FALSE(vlans["Vlan1000"].is_option_79);
+  EXPECT_TRUE(vlans["Vlan1000"].is_interface_id);
+
+  // Remove: an empty desired map tears the vlan down.
+  std::unordered_map<std::string, relay_config> empty_desired;
+  added = apply_desired_config(vlans, empty_desired);
+  EXPECT_FALSE(added);
+  EXPECT_EQ(vlans.count("Vlan1000"), 0);
+}
+
+TEST(relay, apply_desired_config_rebuilds_active_servers_sock) {
+  std::unordered_map<std::string, relay_config> vlans;
+  std::unordered_map<std::string, relay_config> desired;
+
+  // An already-active vlan (is_lla_ready true) with a cached sockaddr list.
+  relay_config live{};
+  live.interface = "Vlan1000";
+  live.servers = {"fc02:2000::1"};
+  live.is_lla_ready = true;
+  build_servers_sock(live);
+  EXPECT_EQ(live.servers_sock.size(), 1);
+  vlans["Vlan1000"] = live;
+
+  // Desired adds a second server; the cached sockaddr list must be rebuilt.
+  relay_config d{};
+  d.interface = "Vlan1000";
+  d.servers = {"fc02:2000::1", "fc02:2000::2"};
+  desired["Vlan1000"] = d;
+
+  bool added = apply_desired_config(vlans, desired);
+  EXPECT_FALSE(added);
+  EXPECT_EQ(vlans["Vlan1000"].servers.size(), 2);
+  EXPECT_EQ(vlans["Vlan1000"].servers_sock.size(), 2);
+}
+
+TEST(relay, teardown_vlan_relay_active) {
+  // An active relay (lla ready) owns a libevent event and two sockets; teardown
+  // must free the event, close both sockets and clear the global lookup maps.
+  base = event_base_new();
+  ASSERT_NE(base, nullptr);
+
+  struct relay_config config{};
+  config.interface = "Vlan2000";
+  config.is_lla_ready = true;
+  config.gua_sock = socket(AF_INET6, SOCK_DGRAM, 0);
+  config.lla_sock = socket(AF_INET6, SOCK_DGRAM, 0);
+  ASSERT_GT(config.gua_sock, 0);
+  ASSERT_GT(config.lla_sock, 0);
+  config.server_event = event_new(base, config.gua_sock, EV_READ | EV_PERSIST, server_callback, &config);
+  ASSERT_NE(config.server_event, nullptr);
+
+  vlan_map["Ethernet4"] = "Vlan2000";
+  addr_vlan_map["fc02:2000::1"] = "Vlan2000";
+
+  ASSERT_NO_THROW(teardown_vlan_relay(config));
+
+  EXPECT_EQ(config.server_event, nullptr);
+  EXPECT_EQ(config.gua_sock, -1);
+  EXPECT_EQ(config.lla_sock, -1);
+  EXPECT_EQ(vlan_map.count("Ethernet4"), 0);
+  EXPECT_EQ(addr_vlan_map.count("fc02:2000::1"), 0);
+
+  event_base_free(base);
+  base = nullptr;
+}
+
+TEST(relay, config_change_callback_remove) {
+  // No desired config has been published yet, so the callback must drain the
+  // notify pipe, fetch the (empty) desired config and remove the live vlan.
+  std::unordered_map<std::string, relay_config> vlans;
+  relay_config c{};
+  c.interface = "Vlan1000";
+  c.is_lla_ready = false;
+  c.server_event = nullptr;
+  vlans["Vlan1000"] = c;
+
+  int pipefd[2];
+  ASSERT_EQ(pipe(pipefd), 0);
+  evutil_make_socket_nonblocking(pipefd[0]);
+  char wake = 1;
+  ASSERT_EQ(write(pipefd[1], &wake, 1), 1);
+
+  config_apply_ctx ctx{};
+  ctx.vlans = &vlans;
+  ctx.timer_args = nullptr;
+  ctx.timer_event = nullptr;
+  ctx.notify_rd = pipefd[0];
+
+  ASSERT_NO_THROW(config_change_callback(pipefd[0], 0, &ctx));
+  EXPECT_EQ(vlans.count("Vlan1000"), 0);
+
+  close(pipefd[0]);
+  close(pipefd[1]);
+}
+
+TEST(relay, config_change_callback_interface_ready_pending_lla) {
+  // A vlan that is configured but whose interface is not yet link-local ready
+  // must trigger the lla-check arming path even though no vlan is newly added
+  // (the interface-ready signal arrives via STATE_DB INTERFACE_TABLE). The
+  // callback must re-arm the timer and fire the lla check without throwing.
+  base = event_base_new();
+  ASSERT_NE(base, nullptr);
+
+  // Clear DHCP_RELAY so the published desired config contains only Vlan9100,
+  // making 'desired' match 'live' exactly (added==false, so pending_lla is what
+  // drives the arming path).
+  std::shared_ptr<swss::DBConnector> config_db = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
+  for (const auto &k : config_db->keys("DHCP_RELAY|*")) {
+    config_db->del(k);
+  }
+  config_db->hset("DHCP_RELAY|Vlan9100", "dhcpv6_servers@", "fc02:9100::1");
+  config_db->hset("VLAN_INTERFACE|Vlan9100|fc02:9100::1", "", "");
+
+  // Publish {Vlan9100} into the global desired config via a brief monitor cycle.
+  int notify[2];
+  ASSERT_EQ(pipe(notify), 0);
+  ASSERT_NO_THROW(start_dhcp_config_monitor(notify[1]));
+  std::this_thread::sleep_for(std::chrono::milliseconds(600));
+  ASSERT_NO_THROW(stop_dhcp_config_monitor());
+  std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+  close(notify[0]);
+  close(notify[1]);
+
+  std::unordered_map<std::string, relay_config> published;
+  ASSERT_TRUE(fetch_desired_config(published));
+  ASSERT_EQ(published.count("Vlan9100"), 1);
+
+  // Live map already has Vlan9100 but it is not lla ready yet (interface down).
+  std::unordered_map<std::string, relay_config> vlans;
+  relay_config c{};
+  c.interface = "Vlan9100";
+  c.servers = {"fc02:9100::1"};
+  c.is_lla_ready = false;
+  c.server_event = nullptr;
+  vlans["Vlan9100"] = c;
+
+  // Build a valid timer_args tuple (same shape lla_check_callback expects) and a
+  // real timer event so the pending-lla arming path can run end to end.
+  auto state_db = std::make_shared<swss::DBConnector>("STATE_DB", 0);
+  std::shared_ptr<swss::Table> mux_table = nullptr;
+  std::vector<int> sockets;
+  auto timer_args = new std::tuple<
+      std::unordered_map<std::string, struct relay_config> &,
+      std::shared_ptr<swss::DBConnector>,
+      std::shared_ptr<swss::DBConnector>,
+      std::shared_ptr<swss::Table>,
+      std::vector<int>,
+      int,
+      int,
+      struct event *
+  >(vlans, config_db, state_db, mux_table, sockets, 0, 0, nullptr);
+  struct event *timer_event = event_new(base, -1, EV_PERSIST, lla_check_callback, timer_args);
+  ASSERT_NE(timer_event, nullptr);
+  std::get<7>(*timer_args) = timer_event;
+
+  int pipefd[2];
+  ASSERT_EQ(pipe(pipefd), 0);
+  evutil_make_socket_nonblocking(pipefd[0]);
+  char wake = 1;
+  ASSERT_EQ(write(pipefd[1], &wake, 1), 1);
+
+  config_apply_ctx ctx{};
+  ctx.vlans = &vlans;
+  ctx.timer_args = timer_args;
+  ctx.timer_event = timer_event;
+  ctx.notify_rd = pipefd[0];
+
+  // Vlan9100 stays configured (still in desired) and not lla ready, so the
+  // pending-lla branch must arm the timer (event_add is globally mocked) and run
+  // the lla check.
+  EXPECT_GLOBAL_CALL(event_add, event_add(_, _)).Times(1).WillOnce(Return(0));
+  ASSERT_NO_THROW(config_change_callback(pipefd[0], 0, &ctx));
+  EXPECT_EQ(vlans.count("Vlan9100"), 1);
+  EXPECT_FALSE(vlans["Vlan9100"].is_lla_ready);
+
+  // Clean up the keys this test added so it does not perturb the shared redis
+  // state other tests rely on.
+  config_db->del("DHCP_RELAY|Vlan9100");
+  config_db->del("VLAN_INTERFACE|Vlan9100|fc02:9100::1");
+
+  event_del(timer_event);
+  event_free(timer_event);
+  delete timer_args;
+  event_base_free(base);
+  base = nullptr;
+  close(pipefd[0]);
+  close(pipefd[1]);
 }
 
 

--- a/dhcp6relay/test/mock_relay.cpp
+++ b/dhcp6relay/test/mock_relay.cpp
@@ -446,6 +446,57 @@ TEST(relay, relay_client)
   }
 }
 
+TEST(relay, relay_client_server_vrf_not_ready_drops)
+{
+  // When an explicit server_vrf is configured but its shared per-VRF socket is
+  // not yet ready (lookup returns -1), relay_client MUST drop the relay-forward
+  // instead of falling back to the per-vlan gua socket -- otherwise a client's
+  // relay-forward would leak into the wrong VRF. (Regression guard: the client
+  // path must honour server_vrf, not only the relay-of-relay path.)
+  uint8_t msg[] = {
+      0x01, 0x2f, 0xf4, 0xc8, 0x00, 0x01, 0x00, 0x0e,
+      0x00, 0x01, 0x00, 0x01, 0x25, 0x3a, 0x37, 0xb9,
+      0x5a, 0xc6, 0xb0, 0x12, 0xe8, 0xb4, 0x00, 0x06,
+      0x00, 0x04, 0x00, 0x17, 0x00, 0x18, 0x00, 0x08,
+      0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x0c,
+      0xb0, 0x12, 0xe8, 0xb4, 0x00, 0x00, 0x0e, 0x10,
+      0x00, 0x00, 0x15, 0x18
+  };
+  int32_t msg_len = sizeof(msg);
+
+  struct relay_config config{};
+  config.is_option_79 = true;
+  config.is_interface_id = true;
+  config.gua_sock = mock_sock;
+  config.lla_sock = mock_sock;
+  config.lo_sock = mock_sock;
+  config.server_vrf = "Vrf-NOSOCK-TEST";
+  sockaddr_in6 tmp{};
+  inet_pton(AF_INET6, "fc02:2000::1", &tmp.sin6_addr);
+  tmp.sin6_family = AF_INET6;
+  tmp.sin6_port = htons(RELAY_PORT);
+  config.servers_sock.push_back(tmp);
+  std::shared_ptr<swss::DBConnector> state_db = std::make_shared<swss::DBConnector> ("STATE_DB", 0);
+  config.state_db = state_db;
+
+  struct ether_header ether_hdr;
+  ether_hdr.ether_shost[0] = 0x5a;
+  ether_hdr.ether_shost[1] = 0xc6;
+  ether_hdr.ether_shost[2] = 0xb0;
+  ether_hdr.ether_shost[3] = 0x12;
+  ether_hdr.ether_shost[4] = 0xe8;
+  ether_hdr.ether_shost[5] = 0xb4;
+
+  ip6_hdr ip_hdr;
+  inet_pton(AF_INET6, "2000::3", &ip_hdr.ip6_src);
+
+  dual_tor_sock = false;
+  last_used_sock = -999;
+  ASSERT_NO_THROW(relay_client(msg, msg_len, &ip_hdr, &ether_hdr, &config));
+  // server_vrf configured but its socket is absent -> dropped, NOT sent on gua_sock
+  EXPECT_EQ(last_used_sock, -999);
+}
+
 TEST(relay, relay_relay_forw) {
   uint8_t msg[] = {
       0x0c, 0x00, 0x20, 0x01, 0x0d, 0xb8, 0x01, 0x5a,
@@ -1291,6 +1342,139 @@ TEST(relay, teardown_vlan_relay_active) {
 
   event_base_free(base);
   base = nullptr;
+}
+
+TEST(relay, apply_desired_config_vrf_change_inactive_updates_in_place) {
+  // A vlan whose relay is not yet armed (lla not ready): a VRF change is just
+  // recorded; the socket is created later by lla_check_callback under the new
+  // VRF, so no teardown and no re-arm request are needed.
+  std::unordered_map<std::string, relay_config> vlans;
+  std::unordered_map<std::string, relay_config> desired;
+
+  relay_config live{};
+  live.interface = "Vlan1000";
+  live.servers = {"fc02:2000::1"};
+  live.vrf = "default";
+  live.is_lla_ready = false;
+  vlans["Vlan1000"] = live;
+
+  relay_config d{};
+  d.interface = "Vlan1000";
+  d.servers = {"fc02:2000::1"};
+  d.vrf = "Vrf-RED";
+  desired["Vlan1000"] = d;
+
+  bool added = apply_desired_config(vlans, desired);
+  EXPECT_FALSE(added);
+  EXPECT_EQ(vlans["Vlan1000"].vrf, "Vrf-RED");
+  EXPECT_FALSE(vlans["Vlan1000"].is_lla_ready);
+}
+
+TEST(relay, apply_desired_config_vrf_change_active_rebinds) {
+  // An active relay (lla ready) bound to the default VRF; moving it to a
+  // non-default VRF must tear the relay down (so the upstream socket is later
+  // recreated with SO_BINDTODEVICE under the new VRF) and request re-arming.
+  base = event_base_new();
+  ASSERT_NE(base, nullptr);
+
+  std::unordered_map<std::string, relay_config> vlans;
+  std::unordered_map<std::string, relay_config> desired;
+
+  relay_config live{};
+  live.interface = "Vlan3000";
+  live.servers = {"fc02:3000::1"};
+  live.vrf = "default";
+  live.is_lla_ready = true;
+  live.gua_sock = socket(AF_INET6, SOCK_DGRAM, 0);
+  live.lla_sock = socket(AF_INET6, SOCK_DGRAM, 0);
+  ASSERT_GT(live.gua_sock, 0);
+  ASSERT_GT(live.lla_sock, 0);
+  live.server_event = event_new(base, live.gua_sock, EV_READ | EV_PERSIST, server_callback, &live);
+  ASSERT_NE(live.server_event, nullptr);
+  vlans["Vlan3000"] = live;
+
+  relay_config d{};
+  d.interface = "Vlan3000";
+  d.servers = {"fc02:3000::1"};
+  d.vrf = "Vrf-RED";
+  desired["Vlan3000"] = d;
+
+  bool added = apply_desired_config(vlans, desired);
+  EXPECT_TRUE(added);                               // re-arm requested
+  EXPECT_EQ(vlans["Vlan3000"].vrf, "Vrf-RED");      // new VRF recorded
+  EXPECT_FALSE(vlans["Vlan3000"].is_lla_ready);     // reset so lla_check re-arms
+  EXPECT_EQ(vlans["Vlan3000"].server_event, nullptr); // event freed by teardown
+  EXPECT_EQ(vlans["Vlan3000"].gua_sock, -1);          // socket closed by teardown
+
+  event_base_free(base);
+  base = nullptr;
+}
+
+TEST(relay, apply_desired_config_server_vrf_change_flows_through) {
+  // Setting an explicit server_vrf on a not-yet-armed vlan is recorded so the
+  // arming path can route relay-forward through the shared server-VRF socket.
+  std::unordered_map<std::string, relay_config> vlans;
+  std::unordered_map<std::string, relay_config> desired;
+
+  relay_config live{};
+  live.interface = "Vlan1000";
+  live.servers = {"fc02:2000::1"};
+  live.vrf = "Vrf-RED";
+  live.server_vrf = "";
+  live.is_lla_ready = false;
+  vlans["Vlan1000"] = live;
+
+  relay_config d{};
+  d.interface = "Vlan1000";
+  d.servers = {"fc02:2000::1"};
+  d.vrf = "Vrf-RED";
+  d.server_vrf = "Vrf-BLUE";
+  desired["Vlan1000"] = d;
+
+  bool added = apply_desired_config(vlans, desired);
+  EXPECT_FALSE(added);
+  EXPECT_EQ(vlans["Vlan1000"].vrf, "Vrf-RED");
+  EXPECT_EQ(vlans["Vlan1000"].server_vrf, "Vrf-BLUE");
+}
+
+TEST(relay, release_server_vrf_sock_frees_only_when_unreferenced) {
+  // The shared server-VRF socket must persist while any live vlan still names
+  // that server_vrf, and be closed + dropped from the map once the last one is
+  // gone -- so a server VRF that is deleted and recreated does not leave a stale
+  // SO_BINDTODEVICE socket behind for get_or_create_server_vrf_sock to reuse.
+  const std::string vrf = "Vrf-REL-TEST";
+  g_server_vrf_socks.erase(vrf);
+
+  // Arm a placeholder shared socket (a plain UDP fd is enough here; the real
+  // arming path additionally SO_BINDTODEVICE-binds it, which needs a live VRF
+  // device that does not exist in the unit-test environment).
+  int fd = socket(AF_INET6, SOCK_DGRAM, 0);
+  ASSERT_GT(fd, 0);
+  g_server_vrf_socks[vrf] = {fd, nullptr};
+  EXPECT_EQ(lookup_server_vrf_sock(vrf), fd);
+
+  // A live vlan still references the server VRF -> the socket is kept.
+  std::unordered_map<std::string, relay_config> vlans;
+  relay_config user{};
+  user.interface = "Vlan1000";
+  user.server_vrf = vrf;
+  vlans["Vlan1000"] = user;
+  release_server_vrf_sock_if_unused(vrf, vlans);
+  EXPECT_EQ(lookup_server_vrf_sock(vrf), fd);
+
+  // A vlan using a *different* server VRF does not keep this one alive: once the
+  // last referrer is removed, the socket is closed and dropped from the map.
+  relay_config other{};
+  other.interface = "Vlan2000";
+  other.server_vrf = "Vrf-OTHER";
+  vlans["Vlan2000"] = other;
+  vlans.erase("Vlan1000");
+  release_server_vrf_sock_if_unused(vrf, vlans);
+  EXPECT_EQ(lookup_server_vrf_sock(vrf), -1);
+
+  // Idempotent: releasing an already-absent or empty VRF is a safe no-op.
+  ASSERT_NO_THROW(release_server_vrf_sock_if_unused(vrf, vlans));
+  ASSERT_NO_THROW(release_server_vrf_sock_if_unused("", vlans));
 }
 
 TEST(relay, config_change_callback_remove) {


### PR DESCRIPTION
#### Why I did it
`dhcp6relay` always sent relay-forward to the DHCPv6 servers through the global routing table, so it could not reach servers that live in a non-default VRF. Fixes sonic-net/sonic-dhcp-relay#89.

#### How I did it
Bind the upstream (server-facing) socket to a VRF via `SO_BINDTODEVICE`:
- **Option A** — a relay VLAN placed in a non-default VRF (`VLAN_INTERFACE` `vrf_name`): the per-VLAN upstream socket is bound to that VRF.
- **Option B** — an explicit `server_vrf` on the `DHCP_RELAY` row (servers reachable in a VRF different from the VLAN's): a shared per-VRF upstream socket is opened, demultiplexed back to the owning VLAN by link-address. The shared socket is released once the last VLAN referencing it is removed/re-pointed, so a deleted/recreated server VRF leaves no stale socket behind.

All applied at runtime through the existing reconcile path — no container restart. A runtime VRF change tears the relay down and re-arms it — `SO_BINDTODEVICE` cannot be rebound in place, so the upstream sockets are recreated under the new VRF.

#### How to verify it
- 68/68 unit tests pass (`make test`), including new coverage for the server-VRF socket lifecycle.
- On a qfx5200 t0 hardware testbed: the existing v6 relay suite passes (no regression) plus new control-plane and data-plane VRF tests.

> Stacked on #116 — until #116 merges this PR's diff also shows #116's commit; it will be rebased to a clean diff afterwards.

