### PR TITLE
[dhcp4relay] Use VLAN giaddr for BOOTP

### DIFF
--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -573,7 +573,10 @@ void encode_relay_option(pcpp::DhcpLayer *dhcp_pkt, relay_config *config) {
 void from_client(pcpp::DhcpLayer *dhcp_pkt, relay_config &config) {
     /* Update giaddr */
     if (!(dhcp_pkt->getDhcpHeader()->gatewayIpAddress)) {
-        if (config.source_interface.length() > 0) {
+        const bool is_dhcp =
+            dhcp_pkt->getDhcpHeader()->magicNumber == DHCP_MAGIC_NUMBER;
+
+        if (is_dhcp && config.source_interface.length() > 0) {
             /* find the IP of the interface and update to giaddr */
             dhcp_pkt->getDhcpHeader()->gatewayIpAddress =
                 config.src_intf_sel_addr.sin_addr.s_addr;
@@ -588,8 +591,7 @@ void from_client(pcpp::DhcpLayer *dhcp_pkt, relay_config &config) {
             dhcp_cntr_table.increment_counter(config.vlan, "TX", DHCPv4_MESSAGE_TYPE_DROP);
             return;
         }
-        if ((dhcp_pkt->getDhcpHeader()->magicNumber) &&
-            (dhcp_pkt->getDhcpHeader()->magicNumber) == DHCP_MAGIC_NUMBER) {
+        if (is_dhcp) {
             SWSS_LOG_WARN("[DHCPV4_RELAY] encode DHCP relay option");
             encode_relay_option(dhcp_pkt, &config);
         }

--- a/dhcp4relay/test/mock_relay.cpp
+++ b/dhcp4relay/test/mock_relay.cpp
@@ -975,6 +975,76 @@ TEST(DHCPRelayTest, from_client) {
     from_client(&dhcpLayer, config);
 }
 
+static relay_config make_from_client_giaddr_config(bool use_source_interface) {
+    interface_list.push_back("Ethernet12");
+    phy_interface_alias_map["Ethernet12"] = "eth12";
+
+    relay_config config = {};
+    config.phy_interface = "Ethernet12";
+    config.vlan = "Vlan10";
+    config.source_interface = use_source_interface ? "Loopback0" : "";
+    config.src_intf_sel_addr.sin_addr.s_addr = inet_addr("10.1.0.32");
+    config.link_address.sin_addr.s_addr = inet_addr("192.168.10.10");
+    config.link_address_netmask.sin_addr.s_addr = inet_addr("255.255.255.0");
+
+    struct sockaddr_in addr = {0};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = inet_addr("192.168.20.100");
+    config.servers_sock = {addr};
+    config.servers = {"192.168.20.100"};
+
+    m_config.hostname = "sonic";
+    m_config.host_mac_addr = "12:32:54:24:95:36";
+    return config;
+}
+
+static void verify_from_client_giaddr(bool is_dhcp, bool use_source_interface,
+                                      const char *expected_giaddr) {
+    pcpp::MacAddress clientMac(std::string("00:0e:86:11:c0:75"));
+    pcpp::DhcpLayer dhcpLayer(pcpp::DHCP_DISCOVER, clientMac);
+    dhcpLayer.getDhcpHeader()->gatewayIpAddress = 0;
+    dhcpLayer.getDhcpHeader()->magicNumber =
+        is_dhcp ? DHCP_MAGIC_NUMBER : 0;
+
+    relay_config config = make_from_client_giaddr_config(use_source_interface);
+    const uint32_t expected_giaddr_addr = inet_addr(expected_giaddr);
+
+    EXPECT_GLOBAL_CALL(send_udp, send_udp(_, _, _, _, _, _, _)).WillOnce(
+        [expected_giaddr_addr](int, uint8_t *hdr, struct sockaddr_in, uint32_t,
+                               in_addr, bool, bool) {
+            pcpp::dhcp_header *dhcp_hdr =
+                reinterpret_cast<pcpp::dhcp_header *>(hdr);
+            EXPECT_EQ(dhcp_hdr->gatewayIpAddress, expected_giaddr_addr);
+            return true;
+        });
+
+    from_client(&dhcpLayer, config);
+
+    auto agent_option =
+        dhcpLayer.getOptionData(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS);
+    if (is_dhcp) {
+        EXPECT_NE(agent_option.getValue(), nullptr);
+    } else {
+        EXPECT_EQ(agent_option.getValue(), nullptr);
+    }
+}
+
+TEST(DHCPRelayTest, from_client_single_tor_dhcp_uses_vlan_giaddr) {
+    verify_from_client_giaddr(true, false, "192.168.10.10");
+}
+
+TEST(DHCPRelayTest, from_client_single_tor_bootp_uses_vlan_giaddr) {
+    verify_from_client_giaddr(false, false, "192.168.10.10");
+}
+
+TEST(DHCPRelayTest, from_client_dual_tor_dhcp_uses_source_interface_giaddr) {
+    verify_from_client_giaddr(true, true, "10.1.0.32");
+}
+
+TEST(DHCPRelayTest, from_client_dual_tor_bootp_uses_vlan_giaddr) {
+    verify_from_client_giaddr(false, true, "192.168.10.10");
+}
+
 /* Helper: build a relay-of-relay packet (giaddr already set) with a pre-existing Option 82. */
 static relay_config make_relay_of_relay_config(const std::string &agent_relay_mode) {
     interface_list.push_back("Ethernet12");


### PR DESCRIPTION
#### Why I did it

Fix dual-ToR BOOTP forwarding by keeping `giaddr` on the receiving client VLAN. Regular DHCP continues to use the configured source interface because Option 82 identifies the client link; BOOTP has no Option 82 and therefore requires the VLAN address for the reply path.

##### Work item tracking
- Microsoft ADO **(number only)**: 38538173

#### How I did it

- Treat packets with the DHCP magic cookie as DHCP.
- Use source-interface `giaddr` selection only for DHCP.
- Keep BOOTP `giaddr` on the VLAN link address because BOOTP has no Option 82.
- Add focused coverage for single-ToR and dual-ToR DHCP and BOOTP.

#### How to verify it

Run the relay unit/build checks and the sonic-mgmt `test_dhcp_relay_default` and `test_dhcp_relay_unicast_mac` cases for ISC and SONiC relay agents on physical m0 and dual-ToR testbeds.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

This regression affects the 202605 DHCP relay behavior and its nightly validation.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/38538173
Failure type: regression

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: Azure build [1168411](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1168411) - all repository checks passed, including amd64, arm64, and armhf builds/tests.
- 202605: `SONiC.20260510.06` - exact PR head `92124a680747a4c4d6c4c1c8d1a31945e37f9ac2` was included in the CI-built relay validation artifact. On physical m0 and dual-ToR testbeds, `test_dhcp_relay_default` and `test_dhcp_relay_unicast_mac` passed for both ISC and SONiC relay agents; `test_dhcp_relay_default[sonic-relay-agent]` passed five consecutive runs on each topology. Evidence: https://github.com/sonic-net/sonic-dhcp-relay/pull/120#issuecomment-5022408814

#### Description for the changelog

Keep BOOTP `giaddr` on the receiving VLAN while retaining source-interface selection for DHCP.

#### Link to config_db schema for YANG module changes

N/A - no YANG or CONFIG_DB schema changes.
