### PR TITLE
[dhcp4relay] Fix Link Selection address mismatch with ISC

### DIFF
--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -517,6 +517,7 @@ void encode_relay_option(pcpp::DhcpLayer *dhcp_pkt, relay_config *config) {
     /* TODO: this sub-option should be set if source interface selection is enabled */
     /* | 5 | 4 | ipv4 | */
     if (m_config.is_dualTor || config->link_selection_opt == "enable") {
+        /* RFC 3527 specifies an address contained in the client subnet; match ISC's VLAN address. */
         uint32_t link_sel_ip = config->link_address.sin_addr.s_addr;
         offset = encode_tlv((buf + buf_offset), OPTION82_SUBOPT_LINK_SELECTION, sizeof(uint32_t),
                             (uint8_t *)&link_sel_ip);

--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -517,8 +517,7 @@ void encode_relay_option(pcpp::DhcpLayer *dhcp_pkt, relay_config *config) {
     /* TODO: this sub-option should be set if source interface selection is enabled */
     /* | 5 | 4 | ipv4 | */
     if (m_config.is_dualTor || config->link_selection_opt == "enable") {
-        uint32_t link_sel_ip = ((config->link_address.sin_addr.s_addr) &
-                                (config->link_address_netmask.sin_addr.s_addr));
+        uint32_t link_sel_ip = config->link_address.sin_addr.s_addr;
         offset = encode_tlv((buf + buf_offset), OPTION82_SUBOPT_LINK_SELECTION, sizeof(uint32_t),
                             (uint8_t *)&link_sel_ip);
         buf_offset += offset;

--- a/dhcp4relay/test/mock_relay.cpp
+++ b/dhcp4relay/test/mock_relay.cpp
@@ -795,7 +795,10 @@ TEST(DHCPRelayTest, encode_relay_option) {
     uint8_t link_sel_len = 0;
     auto link_sel_ip_ptr = decode_tlv((const uint8_t *)options_ptr, OPTION82_SUBOPT_LINK_SELECTION,
                                         link_sel_len, agent_option_size);
-    auto link_sel_ip = *((uint32_t *)link_sel_ip_ptr);
+    ASSERT_NE(link_sel_ip_ptr, nullptr);
+    ASSERT_EQ(link_sel_len, sizeof(uint32_t));
+    uint32_t link_sel_ip;
+    memcpy(&link_sel_ip, link_sel_ip_ptr, sizeof(link_sel_ip));
     EXPECT_EQ(config.link_address.sin_addr.s_addr, link_sel_ip);
 
     auto srv_ovr_ride = decode_tlv((const uint8_t *)options_ptr, OPTION82_SUBOPT_SERVER_OVERRIDE,
@@ -870,7 +873,10 @@ TEST(DHCPRelayTest, encode_relay_option_server_client_same_vrf) {
     uint8_t link_sel_len = 0;
     auto link_sel_ip_ptr = decode_tlv((const uint8_t *)options_ptr, OPTION82_SUBOPT_LINK_SELECTION,
                                         link_sel_len, agent_option_size);
-    auto link_sel_ip = *((uint32_t *)link_sel_ip_ptr);
+    ASSERT_NE(link_sel_ip_ptr, nullptr);
+    ASSERT_EQ(link_sel_len, sizeof(uint32_t));
+    uint32_t link_sel_ip;
+    memcpy(&link_sel_ip, link_sel_ip_ptr, sizeof(link_sel_ip));
     EXPECT_EQ(config.link_address.sin_addr.s_addr, link_sel_ip);
 
     auto srv_ovr_ride = decode_tlv((const uint8_t *)options_ptr, OPTION82_SUBOPT_SERVER_OVERRIDE,

--- a/dhcp4relay/test/mock_relay.cpp
+++ b/dhcp4relay/test/mock_relay.cpp
@@ -801,10 +801,14 @@ TEST(DHCPRelayTest, encode_relay_option) {
     memcpy(&link_sel_ip, link_sel_ip_ptr, sizeof(link_sel_ip));
     EXPECT_EQ(config.link_address.sin_addr.s_addr, link_sel_ip);
 
-    auto srv_ovr_ride = decode_tlv((const uint8_t *)options_ptr, OPTION82_SUBOPT_SERVER_OVERRIDE,
-                                    link_sel_len, agent_option_size);
-    auto srv_ip = *((uint32_t *)srv_ovr_ride);
-    EXPECT_EQ(srv_ip, config.link_address.sin_addr.s_addr);
+    uint8_t server_override_len = 0;
+    auto server_override_ptr = decode_tlv((const uint8_t *)options_ptr, OPTION82_SUBOPT_SERVER_OVERRIDE,
+                                           server_override_len, agent_option_size);
+    ASSERT_NE(server_override_ptr, nullptr);
+    ASSERT_EQ(server_override_len, sizeof(uint32_t));
+    uint32_t server_override_ip;
+    memcpy(&server_override_ip, server_override_ptr, sizeof(server_override_ip));
+    EXPECT_EQ(server_override_ip, config.link_address.sin_addr.s_addr);
 
     uint8_t vrf_len = 0;
     auto vrf_ptr = decode_tlv((const uint8_t *)options_ptr, OPTION82_SUBOPT_VIRTUAL_SUBNET,
@@ -879,10 +883,14 @@ TEST(DHCPRelayTest, encode_relay_option_server_client_same_vrf) {
     memcpy(&link_sel_ip, link_sel_ip_ptr, sizeof(link_sel_ip));
     EXPECT_EQ(config.link_address.sin_addr.s_addr, link_sel_ip);
 
-    auto srv_ovr_ride = decode_tlv((const uint8_t *)options_ptr, OPTION82_SUBOPT_SERVER_OVERRIDE,
-                                    link_sel_len, agent_option_size);
-    auto srv_ip = *((uint32_t *)srv_ovr_ride);
-    EXPECT_EQ(srv_ip, config.link_address.sin_addr.s_addr);
+    uint8_t server_override_len = 0;
+    auto server_override_ptr = decode_tlv((const uint8_t *)options_ptr, OPTION82_SUBOPT_SERVER_OVERRIDE,
+                                           server_override_len, agent_option_size);
+    ASSERT_NE(server_override_ptr, nullptr);
+    ASSERT_EQ(server_override_len, sizeof(uint32_t));
+    uint32_t server_override_ip;
+    memcpy(&server_override_ip, server_override_ptr, sizeof(server_override_ip));
+    EXPECT_EQ(server_override_ip, config.link_address.sin_addr.s_addr);
 
     uint8_t vrf_len = 0;
     uint8_t *vrf_ptr = NULL;

--- a/dhcp4relay/test/mock_relay.cpp
+++ b/dhcp4relay/test/mock_relay.cpp
@@ -796,7 +796,7 @@ TEST(DHCPRelayTest, encode_relay_option) {
     auto link_sel_ip_ptr = decode_tlv((const uint8_t *)options_ptr, OPTION82_SUBOPT_LINK_SELECTION,
                                         link_sel_len, agent_option_size);
     auto link_sel_ip = *((uint32_t *)link_sel_ip_ptr);
-    EXPECT_EQ((config.link_address.sin_addr.s_addr & config.link_address_netmask.sin_addr.s_addr), link_sel_ip);
+    EXPECT_EQ(config.link_address.sin_addr.s_addr, link_sel_ip);
 
     auto srv_ovr_ride = decode_tlv((const uint8_t *)options_ptr, OPTION82_SUBOPT_SERVER_OVERRIDE,
                                     link_sel_len, agent_option_size);
@@ -871,7 +871,7 @@ TEST(DHCPRelayTest, encode_relay_option_server_client_same_vrf) {
     auto link_sel_ip_ptr = decode_tlv((const uint8_t *)options_ptr, OPTION82_SUBOPT_LINK_SELECTION,
                                         link_sel_len, agent_option_size);
     auto link_sel_ip = *((uint32_t *)link_sel_ip_ptr);
-    EXPECT_EQ((config.link_address.sin_addr.s_addr & config.link_address_netmask.sin_addr.s_addr), link_sel_ip);
+    EXPECT_EQ(config.link_address.sin_addr.s_addr, link_sel_ip);
 
     auto srv_ovr_ride = decode_tlv((const uint8_t *)options_ptr, OPTION82_SUBOPT_SERVER_OVERRIDE,
                                     link_sel_len, agent_option_size);


### PR DESCRIPTION
#### Why I did it

SONiC encodes the subnet network address in DHCP Option 82 Suboption 5 by masking the receiving VLAN address. ISC `dhcrelay` emits the receiving VLAN interface address directly.

This mismatch is an existing product defect because Link Selection is consumed as an address contained in the client subnet. It also breaks the matching sonic-mgmt validation: https://github.com/sonic-net/sonic-mgmt/pull/26108 expects the ISC-compatible VLAN address, while an image without this fix still emits the masked network address. The `source_intf-sonic-relay-agent` case then receives zero matching relayed DISCOVER packets instead of the expected four.

RFC 3527 describes Suboption 5 as a single address contained in a subnet. Kea follows that interpretation by selecting a configured subnet whose range contains the supplied address. Using the receiving VLAN address preserves the correct subnet identity and aligns SONiC with deployed ISC behavior.

##### Work item tracking
- Microsoft ADO **(number only)**: 38778666

#### How I did it

- Encode `config.link_address` directly in Link Selection instead of masking it with the VLAN netmask.
- Update the focused Option 82 unit expectations.
- Preserve the existing suboption order: Circuit-ID, Remote-ID, Link Selection, Server-ID Override, then VSS.
- Harden the unit-test TLV reads by validating payload pointers and lengths and using `memcpy` for `uint32_t` values.

#### How to verify it

Run the relay build/unit checks and the sonic-mgmt `test_dhcp_relay_default` and `test_dhcp_relay_unicast_mac` cases for ISC and SONiC relay agents on physical m0 and dual-ToR testbeds.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

The incorrect masked Link Selection value is present in 202605 and causes the dependent sonic-mgmt test to reject every relayed DISCOVER packet from SONiC relay.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/38778666
Failure type: day-one issue

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: Azure build [1170775](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1170775) - all repository checks passed, including amd64, arm64, and armhf builds/tests.
- 202605: `SONiC.20260510.06` - the PR change was included in the CI-built relay validation artifact. On physical m0 and dual-ToR testbeds, `test_dhcp_relay_default` and `test_dhcp_relay_unicast_mac` passed for both ISC and SONiC relay agents; `test_dhcp_relay_default[sonic-relay-agent]` passed five consecutive runs on each topology. Evidence: https://github.com/sonic-net/sonic-dhcp-relay/pull/121#issuecomment-5022409154

#### Description for the changelog

Emit the receiving VLAN address in DHCP Option 82 Link Selection to match ISC and restore correct subnet selection.

#### Link to config_db schema for YANG module changes

N/A - no YANG or CONFIG_DB schema changes.
