### PR TITLE
[dhcp4relay] Apply configured maximum hop count

### DIFF
--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -1291,6 +1291,7 @@ static void apply_config_event(const event_config &received_event,
                     (*vlans)[relay_msg->vlan].server_id_override_opt = relay_msg->server_id_override_opt;
                     (*vlans)[relay_msg->vlan].vrf_selection_opt = relay_msg->vrf_selection_opt;
                     (*vlans)[relay_msg->vlan].agent_relay_mode = relay_msg->agent_relay_mode;
+                    (*vlans)[relay_msg->vlan].max_hop_count = relay_msg->max_hop_count;
                 } else {
                     if (vlans->find(relay_msg->vlan) != vlans->end()) {
                         /* In case of vlan deletion, close all the sockets.*/

--- a/dhcp4relay/src/dhcp4relay.h
+++ b/dhcp4relay/src/dhcp4relay.h
@@ -23,7 +23,7 @@
 
 #define RELAY_PORT 67
 #define CLIENT_PORT 68
-#define HOP_LIMIT 4
+#define DEFAULT_MAX_HOP_COUNT 4
 #define DHCPv4_OPTION_LIMIT 255
 #define RAWSOCKET_RECV_SIZE 1048576
 #define CLIENT_IF_PREFIX "Ethernet"
@@ -117,7 +117,7 @@ struct relay_config {
     std::string server_id_override_opt;
     std::string vrf_selection_opt;
     std::string agent_relay_mode;
-    uint8_t max_hop_count = MAX_HOP_COUNT;
+    uint8_t max_hop_count = DEFAULT_MAX_HOP_COUNT;
     std::vector<std::string> servers;
     std::vector<sockaddr_in> servers_sock;
     bool is_interface_id;

--- a/dhcp4relay/test/mock_relay.cpp
+++ b/dhcp4relay/test/mock_relay.cpp
@@ -277,6 +277,7 @@ TEST(relayConfig, handle_vlan_events) {
     config->source_interface = "Ethernet8";
     config->servers = {"192.168.1.1","10.0.0.1"};
     config->vrf = "default";
+    config->max_hop_count = 2;
     event.type = DHCPv4_RELAY_CONFIG_UPDATE;
     event.msg = static_cast<void *>(config);
     
@@ -288,6 +289,7 @@ TEST(relayConfig, handle_vlan_events) {
     config_event_callback(pipe_fds[0], 0, &vlans);
 
     ASSERT_TRUE(vlans.find("Vlan200") != vlans.end());
+    EXPECT_EQ(vlans["Vlan200"].max_hop_count, 2);
 
     ASSERT_EQ(vlans["Vlan200"].servers_sock.size(), 2);
 
@@ -325,6 +327,44 @@ TEST(relayConfig, handle_vlan_events) {
     close(pipe_fds[0]);
     close(pipe_fds[1]);
     FreeMockIfaddrs(mock_ifaddrs);
+}
+
+TEST(relayConfig, max_hop_count_config_event_propagates_updates) {
+    EXPECT_EQ(relay_config{}.max_hop_count, DEFAULT_MAX_HOP_COUNT);
+    EXPECT_EQ(MAX_HOP_COUNT, 16);
+
+    int pipe_fds[2];
+    ASSERT_NE(pipe(pipe_fds), -1);
+    EXPECT_GLOBAL_CALL(write, write(_, _, _))
+        .Times(2)
+        .WillRepeatedly(Invoke(RealWrite));
+
+    std::unordered_map<std::string, relay_config> vlans;
+    vlans["Vlan100"].vlan = "Vlan100";
+
+    event_config event;
+    event.type = DHCPv4_RELAY_CONFIG_UPDATE;
+
+    relay_config *config = new relay_config();
+    config->vlan = "Vlan100";
+    config->is_add = true;
+    config->max_hop_count = 2;
+    event.msg = static_cast<void *>(config);
+    ASSERT_NE(write(pipe_fds[1], &event, sizeof(event)), -1);
+    config_event_callback(pipe_fds[0], 0, &vlans);
+    EXPECT_EQ(vlans["Vlan100"].max_hop_count, 2);
+
+    config = new relay_config();
+    config->vlan = "Vlan100";
+    config->is_add = true;
+    config->max_hop_count = 8;
+    event.msg = static_cast<void *>(config);
+    ASSERT_NE(write(pipe_fds[1], &event, sizeof(event)), -1);
+    config_event_callback(pipe_fds[0], 0, &vlans);
+    EXPECT_EQ(vlans["Vlan100"].max_hop_count, 8);
+
+    close(pipe_fds[0]);
+    close(pipe_fds[1]);
 }
 
 TEST(relayConfig, handle_interface_events) {


### PR DESCRIPTION
### Description of PR

Summary:

Apply configured DHCPv4 maximum hop counts to active per-VLAN relay state and
use the YANG/RFC-recommended default of 4, while retaining 16 as the distinct
absolute supported maximum.

This is a low-priority placeholder for a non-current deployment scenario. This
draft must not merge yet.

### Type of change

- [x] Bug fix

### Approach

#### What is the motivation for this PR?

`DHCPMgr` parses `max_hop_count`, but the main relay event path does not copy it
into the active VLAN configuration. Runtime behavior therefore remains at the
native struct default, which was incorrectly conflated with the absolute limit
of 16 instead of the configured/YANG default of 4.

#### How did you do it?

- Define 4 as the native default and retain 16 as the absolute supported limit.
- Copy each add/update event's parsed `max_hop_count` into the active VLAN
  `relay_config`.
- Add focused native unit coverage for the default, add propagation, and update
  propagation.

#### How did you verify/test it?

Focused native unit code is included but was **NOT RUN**, per explicit test
deferral. Test execution is deferred until the higher-priority DHCP relay PRs
listed below merge.

#### Any platform specific information?

None. This covers a lower-priority, non-current deployment scenario.

### Dependencies and future validation TODOs

Validation sequencing depends on these higher-priority relay PRs merging first
(no code dependency; this branch is independently based on fresh `origin/master`):

- https://github.com/sonic-net/sonic-dhcp-relay/pull/120
- https://github.com/sonic-net/sonic-dhcp-relay/pull/121
- https://github.com/sonic-net/sonic-dhcp-relay/pull/122

Before marking ready or merging:

- [ ] Execute the focused native unit coverage included in this PR.
- [x] Open the dependent sonic-mgmt PR with threshold-discriminating coverage:
      https://github.com/sonic-net/sonic-mgmt/pull/26321 — configured 2 with
      incoming `hops=2` must drop, and configured 4 with incoming `hops=3`
      must forward after increment.
- [ ] Validate a live CONFIG_DB update changes the active threshold without a
      daemon restart.
- [ ] Run applicable PR CI/hardware validation after the dependency PRs merge.
- [ ] Keep this PR in draft; do not merge before these TODOs are complete.

### Documentation

Behavior aligns the native default with the existing YANG contract and RFC 1542
recommended configurable threshold while preserving the absolute limit of 16.
