### PR TITLE
[dhcp4relay] Reject first-hop requests with relay information

### DIFF
--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -573,6 +573,14 @@ void encode_relay_option(pcpp::DhcpLayer *dhcp_pkt, relay_config *config) {
 void from_client(pcpp::DhcpLayer *dhcp_pkt, relay_config &config) {
     /* Update giaddr */
     if (!(dhcp_pkt->getDhcpHeader()->gatewayIpAddress)) {
+        auto agent_option = dhcp_pkt->getOptionData(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS);
+        if (agent_option.isNotNull()) {
+            SWSS_LOG_NOTICE("[DHCPV4_RELAY] Dropping first-hop packet with pre-existing Option 82 on untrusted interface %s",
+                    config.vlan.c_str());
+            dhcp_cntr_table.increment_counter(config.vlan, "TX", DHCPv4_MESSAGE_TYPE_DROP);
+            return;
+        }
+
         if (config.source_interface.length() > 0) {
             /* find the IP of the interface and update to giaddr */
             dhcp_pkt->getDhcpHeader()->gatewayIpAddress =

--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -560,6 +560,52 @@ void encode_relay_option(pcpp::DhcpLayer *dhcp_pkt, relay_config *config) {
     return;
 }
 
+static bool has_dhcp_option(const pcpp::DhcpLayer *dhcp_pkt,
+                            pcpp::DhcpOptionTypes option_type) {
+    const pcpp::dhcp_header *dhcp_header = dhcp_pkt->getDhcpHeader();
+    if (dhcp_header == nullptr || dhcp_header->magicNumber != DHCP_MAGIC_NUMBER) {
+        return false;
+    }
+
+    size_t remaining = dhcp_pkt->getHeaderLen();
+    if (remaining <= sizeof(pcpp::dhcp_header)) {
+        return false;
+    }
+
+    const uint8_t *option = reinterpret_cast<const uint8_t *>(dhcp_header) +
+                            sizeof(pcpp::dhcp_header);
+    remaining -= sizeof(pcpp::dhcp_header);
+
+    while (remaining > 0) {
+        const uint8_t option_code = *option++;
+        --remaining;
+
+        if (option_code == static_cast<uint8_t>(pcpp::DHCPOPT_PAD)) {
+            continue;
+        }
+        if (option_code == static_cast<uint8_t>(pcpp::DHCPOPT_END)) {
+            return false;
+        }
+        if (remaining == 0) {
+            return false;
+        }
+
+        const uint8_t option_len = *option++;
+        --remaining;
+        if (option_len > remaining) {
+            return false;
+        }
+        if (option_code == static_cast<uint8_t>(option_type)) {
+            return true;
+        }
+
+        option += option_len;
+        remaining -= option_len;
+    }
+
+    return false;
+}
+
 /**
  * @code                 void from_client(pcpp::DhcpLayer* dhcp_pkt, relay_config *config)
  *
@@ -573,8 +619,7 @@ void encode_relay_option(pcpp::DhcpLayer *dhcp_pkt, relay_config *config) {
 void from_client(pcpp::DhcpLayer *dhcp_pkt, relay_config &config) {
     /* Update giaddr */
     if (!(dhcp_pkt->getDhcpHeader()->gatewayIpAddress)) {
-        auto agent_option = dhcp_pkt->getOptionData(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS);
-        if (agent_option.isNotNull()) {
+        if (has_dhcp_option(dhcp_pkt, pcpp::DHCPOPT_DHCP_AGENT_OPTIONS)) {
             SWSS_LOG_NOTICE("[DHCPV4_RELAY] Dropping first-hop packet with pre-existing Option 82 on untrusted interface %s",
                     config.vlan.c_str());
             dhcp_cntr_table.increment_counter(config.vlan, "TX", DHCPv4_MESSAGE_TYPE_DROP);

--- a/dhcp4relay/test/mock_relay.cpp
+++ b/dhcp4relay/test/mock_relay.cpp
@@ -997,6 +997,32 @@ static relay_config make_relay_of_relay_config(const std::string &agent_relay_mo
     return config;
 }
 
+TEST(DHCPRelayTest, from_client_first_hop_with_option82_is_dropped) {
+    relay_config config = make_relay_of_relay_config("discard");
+
+    pcpp::MacAddress clientMac(std::string("00:0e:86:11:c0:75"));
+    pcpp::DhcpLayer dhcpLayer(pcpp::DHCP_DISCOVER, clientMac);
+    dhcpLayer.getDhcpHeader()->hops = 0;
+    dhcpLayer.getDhcpHeader()->gatewayIpAddress = 0;
+    dhcpLayer.getDhcpHeader()->magicNumber = DHCP_MAGIC_NUMBER;
+    encode_relay_option(&dhcpLayer, &config);
+
+    auto original_option =
+        dhcpLayer.getOptionData(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS);
+    ASSERT_TRUE(original_option.isNotNull());
+    const size_t original_header_len = dhcpLayer.getHeaderLen();
+    const size_t original_option_size = original_option.getDataSize();
+
+    EXPECT_GLOBAL_CALL(send_udp, send_udp(_, _, _, _, _, _, _)).Times(0);
+    from_client(&dhcpLayer, config);
+
+    EXPECT_EQ(dhcpLayer.getDhcpHeader()->gatewayIpAddress, 0u);
+    EXPECT_EQ(dhcpLayer.getDhcpHeader()->hops, 0);
+    EXPECT_EQ(dhcpLayer.getHeaderLen(), original_header_len);
+    EXPECT_EQ(dhcpLayer.getOptionData(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS).getDataSize(),
+              original_option_size);
+}
+
 /* agent_relay_mode=append: packet already has Option 82; we should append ours and forward. */
 TEST(DHCPRelayTest, from_client_relay_of_relay_append) {
     relay_config config = make_relay_of_relay_config("append");

--- a/dhcp4relay/test/mock_relay.cpp
+++ b/dhcp4relay/test/mock_relay.cpp
@@ -1023,6 +1023,38 @@ TEST(DHCPRelayTest, from_client_first_hop_with_option82_is_dropped) {
               original_option_size);
 }
 
+TEST(DHCPRelayTest, from_client_first_hop_ignores_option82_after_end) {
+    relay_config config = make_relay_of_relay_config("discard");
+    const uint8_t options[] = {
+        static_cast<uint8_t>(pcpp::DHCPOPT_DHCP_MESSAGE_TYPE), 1,
+        static_cast<uint8_t>(pcpp::DHCP_DISCOVER),
+        static_cast<uint8_t>(pcpp::DHCPOPT_PAD),
+        static_cast<uint8_t>(pcpp::DHCPOPT_END),
+        static_cast<uint8_t>(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS), 2, 1, 0,
+    };
+    const size_t packet_len = sizeof(pcpp::dhcp_header) + sizeof(options);
+    auto *packet = new uint8_t[packet_len]();
+    auto *dhcp_header = reinterpret_cast<pcpp::dhcp_header *>(packet);
+    dhcp_header->magicNumber = DHCP_MAGIC_NUMBER;
+    memcpy(packet + sizeof(pcpp::dhcp_header), options, sizeof(options));
+    pcpp::DhcpLayer dhcpLayer(packet, packet_len, nullptr, nullptr);
+
+    EXPECT_GLOBAL_CALL(send_udp, send_udp(_, _, _, _, _, _, _)).WillOnce([&config]
+            (int, uint8_t *hdr, struct sockaddr_in, uint32_t, in_addr, bool, bool) {
+        auto *forwarded_header = reinterpret_cast<pcpp::dhcp_header *>(hdr);
+        EXPECT_EQ(forwarded_header->gatewayIpAddress,
+                  config.link_address.sin_addr.s_addr);
+        EXPECT_EQ(forwarded_header->hops, 1);
+        return true;
+    });
+
+    from_client(&dhcpLayer, config);
+
+    EXPECT_EQ(dhcpLayer.getDhcpHeader()->gatewayIpAddress,
+              config.link_address.sin_addr.s_addr);
+    EXPECT_GT(dhcpLayer.getHeaderLen(), packet_len);
+}
+
 /* agent_relay_mode=append: packet already has Option 82; we should append ours and forward. */
 TEST(DHCPRelayTest, from_client_relay_of_relay_append) {
     relay_config config = make_relay_of_relay_config("append");


### PR DESCRIPTION
### Description of PR

Summary:

Reject a zero-`giaddr` DHCP request that already contains Option 82 before the
relay assigns `giaddr` or appends another relay information option.

This is a low-priority placeholder for a non-current deployment scenario. This
draft must not merge yet.

### Type of change

- [x] Bug fix

### Approach

#### What is the motivation for this PR?

SONiC has no trusted-circuit configuration. RFC 3046 safe untrusted behavior,
and the SONiC ISC relay default, require dropping a first-hop request that
already carries relay information. The native relay currently assigns `giaddr`
and appends a duplicate Option 82.

#### How did you do it?

- Detect pre-existing Option 82 on zero-`giaddr` client requests.
- Increment the drop counter and emit a clear diagnostic before modifying the
  packet.
- Add focused native unit coverage proving `send_udp` is not called, `giaddr`
  and hops remain unchanged, and no duplicate option is appended.

#### How did you verify/test it?

Focused native unit code is included but was **NOT RUN**, per explicit test
deferral. Test execution is deferred until the higher-priority DHCP relay PRs
listed below merge.

#### Any platform specific information?

None. This covers a lower-priority, non-current deployment scenario.

### Dependencies and future validation TODOs

Validation sequencing depends on these higher-priority relay PRs merging first
(no code dependency; this branch is independently based on fresh `origin/master`):

- https://github.com/sonic-net/sonic-dhcp-relay/pull/120
- https://github.com/sonic-net/sonic-dhcp-relay/pull/121
- https://github.com/sonic-net/sonic-dhcp-relay/pull/122

Before marking ready or merging:

- [ ] Execute the focused native unit coverage included in this PR.
- [x] Open the dependent sonic-mgmt PR that sends zero-`giaddr` DHCP with a
      pre-existing Option 82 and proves no packet reaches the upstream server:
      https://github.com/sonic-net/sonic-mgmt/pull/26322
- [ ] Verify the DHCP relay drop counter and diagnostic for the rejected packet.
- [ ] Run applicable PR CI/hardware validation after the dependency PRs merge.
- [ ] Keep this PR in draft; do not merge before these TODOs are complete.

### Documentation

Behavior follows RFC 3046 untrusted-circuit handling and the SONiC ISC default.
