### PR TITLE
[dhcp4relay] Forward chained requests without relay information

### DIFF
--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -601,7 +601,11 @@ void from_client(pcpp::DhcpLayer *dhcp_pkt, relay_config &config) {
            forward - Forward the packet unchanged (no Option 82 modification).
            discard - Discard the incoming packet (default).
          */
-        if (config.agent_relay_mode == "append") {
+        auto agent_option = dhcp_pkt->getOptionData(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS);
+        if (agent_option.isNull()) {
+            SWSS_LOG_DEBUG("[DHCPV4_RELAY] Forwarding chained packet without Option 82 on %s",
+                    config.vlan.c_str());
+        } else if (config.agent_relay_mode == "append") {
             encode_relay_option(dhcp_pkt, &config);
         } else if (config.agent_relay_mode == "replace") {
             dhcp_pkt->removeOption(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS);

--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -560,6 +560,52 @@ void encode_relay_option(pcpp::DhcpLayer *dhcp_pkt, relay_config *config) {
     return;
 }
 
+static bool has_dhcp_option(const pcpp::DhcpLayer *dhcp_pkt,
+                            pcpp::DhcpOptionTypes option_type) {
+    const pcpp::dhcp_header *dhcp_header = dhcp_pkt->getDhcpHeader();
+    if (dhcp_header == nullptr || dhcp_header->magicNumber != DHCP_MAGIC_NUMBER) {
+        return false;
+    }
+
+    size_t remaining = dhcp_pkt->getHeaderLen();
+    if (remaining <= sizeof(pcpp::dhcp_header)) {
+        return false;
+    }
+
+    const uint8_t *option = reinterpret_cast<const uint8_t *>(dhcp_header) +
+                            sizeof(pcpp::dhcp_header);
+    remaining -= sizeof(pcpp::dhcp_header);
+
+    while (remaining > 0) {
+        const uint8_t option_code = *option++;
+        --remaining;
+
+        if (option_code == static_cast<uint8_t>(pcpp::DHCPOPT_PAD)) {
+            continue;
+        }
+        if (option_code == static_cast<uint8_t>(pcpp::DHCPOPT_END)) {
+            return false;
+        }
+        if (remaining == 0) {
+            return false;
+        }
+
+        const uint8_t option_len = *option++;
+        --remaining;
+        if (option_len > remaining) {
+            return false;
+        }
+        if (option_code == static_cast<uint8_t>(option_type)) {
+            return true;
+        }
+
+        option += option_len;
+        remaining -= option_len;
+    }
+
+    return false;
+}
+
 /**
  * @code                 void from_client(pcpp::DhcpLayer* dhcp_pkt, relay_config *config)
  *
@@ -601,8 +647,7 @@ void from_client(pcpp::DhcpLayer *dhcp_pkt, relay_config &config) {
            forward - Forward the packet unchanged (no Option 82 modification).
            discard - Discard the incoming packet (default).
          */
-        auto agent_option = dhcp_pkt->getOptionData(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS);
-        if (agent_option.isNull()) {
+        if (!has_dhcp_option(dhcp_pkt, pcpp::DHCPOPT_DHCP_AGENT_OPTIONS)) {
             SWSS_LOG_DEBUG("[DHCPV4_RELAY] Forwarding chained packet without Option 82 on %s",
                     config.vlan.c_str());
         } else if (config.agent_relay_mode == "append") {

--- a/dhcp4relay/test/mock_relay.cpp
+++ b/dhcp4relay/test/mock_relay.cpp
@@ -997,6 +997,29 @@ static relay_config make_relay_of_relay_config(const std::string &agent_relay_mo
     return config;
 }
 
+TEST(DHCPRelayTest, from_client_relay_of_relay_without_option82_forwards) {
+    relay_config config = make_relay_of_relay_config("discard");
+
+    pcpp::MacAddress clientMac(std::string("00:0e:86:11:c0:75"));
+    pcpp::DhcpLayer dhcpLayer(pcpp::DHCP_DISCOVER, clientMac);
+    dhcpLayer.getDhcpHeader()->hops = 2;
+    dhcpLayer.getDhcpHeader()->gatewayIpAddress = inet_addr("192.168.1.1");
+
+    EXPECT_GLOBAL_CALL(send_udp, send_udp(_, _, _, _, _, _, _)).WillOnce([]
+            (int, uint8_t *hdr, struct sockaddr_in, uint32_t, in_addr, bool, bool) {
+        pcpp::dhcp_header *dhcp_hdr = reinterpret_cast<pcpp::dhcp_header *>(hdr);
+        EXPECT_EQ(dhcp_hdr->hops, 3);
+        EXPECT_EQ(dhcp_hdr->gatewayIpAddress, inet_addr("192.168.1.1"));
+        return true;
+    });
+
+    from_client(&dhcpLayer, config);
+
+    EXPECT_EQ(dhcpLayer.getDhcpHeader()->hops, 3);
+    EXPECT_EQ(dhcpLayer.getDhcpHeader()->gatewayIpAddress, inet_addr("192.168.1.1"));
+    EXPECT_TRUE(dhcpLayer.getOptionData(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS).isNull());
+}
+
 /* agent_relay_mode=append: packet already has Option 82; we should append ours and forward. */
 TEST(DHCPRelayTest, from_client_relay_of_relay_append) {
     relay_config config = make_relay_of_relay_config("append");

--- a/dhcp4relay/test/mock_relay.cpp
+++ b/dhcp4relay/test/mock_relay.cpp
@@ -1020,6 +1020,38 @@ TEST(DHCPRelayTest, from_client_relay_of_relay_without_option82_forwards) {
     EXPECT_TRUE(dhcpLayer.getOptionData(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS).isNull());
 }
 
+TEST(DHCPRelayTest, from_client_relay_of_relay_ignores_option82_after_end) {
+    relay_config config = make_relay_of_relay_config("discard");
+    const uint8_t options[] = {
+        static_cast<uint8_t>(pcpp::DHCPOPT_DHCP_MESSAGE_TYPE), 1,
+        static_cast<uint8_t>(pcpp::DHCP_DISCOVER),
+        static_cast<uint8_t>(pcpp::DHCPOPT_PAD),
+        static_cast<uint8_t>(pcpp::DHCPOPT_END),
+        static_cast<uint8_t>(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS), 2, 1, 0,
+    };
+    const size_t packet_len = sizeof(pcpp::dhcp_header) + sizeof(options);
+    auto *packet = new uint8_t[packet_len]();
+    auto *dhcp_header = reinterpret_cast<pcpp::dhcp_header *>(packet);
+    dhcp_header->hops = 2;
+    dhcp_header->gatewayIpAddress = inet_addr("192.168.1.1");
+    dhcp_header->magicNumber = DHCP_MAGIC_NUMBER;
+    memcpy(packet + sizeof(pcpp::dhcp_header), options, sizeof(options));
+    pcpp::DhcpLayer dhcpLayer(packet, packet_len, nullptr, nullptr);
+
+    EXPECT_GLOBAL_CALL(send_udp, send_udp(_, _, _, _, _, _, _)).WillOnce([]
+            (int, uint8_t *hdr, struct sockaddr_in, uint32_t, in_addr, bool, bool) {
+        auto *forwarded_header = reinterpret_cast<pcpp::dhcp_header *>(hdr);
+        EXPECT_EQ(forwarded_header->hops, 3);
+        EXPECT_EQ(forwarded_header->gatewayIpAddress, inet_addr("192.168.1.1"));
+        return true;
+    });
+
+    from_client(&dhcpLayer, config);
+
+    EXPECT_EQ(dhcpLayer.getDhcpHeader()->hops, 3);
+    EXPECT_EQ(dhcpLayer.getHeaderLen(), packet_len);
+}
+
 /* agent_relay_mode=append: packet already has Option 82; we should append ours and forward. */
 TEST(DHCPRelayTest, from_client_relay_of_relay_append) {
     relay_config config = make_relay_of_relay_config("append");


### PR DESCRIPTION
### Description of PR

Summary:

Forward nonzero-`giaddr` chained requests that do not contain Option 82 without
applying agent relay mode, adding relay information, or changing `giaddr`.

This is a low-priority placeholder for a non-current deployment scenario. This
draft must not merge yet.

### Type of change

- [x] Bug fix

### Approach

#### What is the motivation for this PR?

The configured agent relay mode describes handling of packets that already
contain relay information. Native relay currently applies it to every nonzero-
`giaddr` request, so default `discard` incorrectly drops a valid chained request
with no Option 82.

#### How did you do it?

- Apply agent relay mode only when a nonzero-`giaddr` request actually contains
  Option 82.
- Otherwise preserve `giaddr`, leave Option 82 absent, and continue normal hop
  limit checking, increment, and forwarding.
- Add focused native unit coverage using discard mode.

#### How did you verify/test it?

Focused native unit code is included but was **NOT RUN**, per explicit test
deferral. Test execution is deferred until the higher-priority DHCP relay PRs
listed below merge.

#### Any platform specific information?

None. This covers a lower-priority, non-current deployment scenario.

### Dependencies and future validation TODOs

Validation sequencing depends on these higher-priority relay PRs merging first
(no code dependency; this branch is independently based on fresh `origin/master`):

- https://github.com/sonic-net/sonic-dhcp-relay/pull/120
- https://github.com/sonic-net/sonic-dhcp-relay/pull/121
- https://github.com/sonic-net/sonic-dhcp-relay/pull/122

Before marking ready or merging:

- [ ] Review this policy against ISC relay behavior before merge.
- [ ] Execute the focused native unit coverage included in this PR.
- [x] Open the dependent sonic-mgmt PR using discard mode and prove a nonzero-
      `giaddr` request without Option 82 forwards, increments hops, preserves
      `giaddr`, and still contains no Option 82:
      https://github.com/sonic-net/sonic-mgmt/pull/26324
- [ ] Run applicable PR CI/hardware validation after the dependency PRs merge.
- [ ] Keep this PR in draft; do not merge before these TODOs are complete.

### Documentation

The policy must be reviewed against ISC behavior before this draft can merge.
